### PR TITLE
Remove dependency on DOM types and declare self/TextEncoder

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,17 @@
 /*! noble-hashes - MIT License (c) 2021 Paul Miller (paulmillr.com) */
 
+// Global symbols in both browsers and Node.js since v11
+// https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder
+// https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder
+// https://nodejs.org/docs/latest-v12.x/api/util.html#util_class_util_textencoder
+// https://nodejs.org/docs/latest-v12.x/api/util.html#util_class_util_textdecoder
+// See https://github.com/microsoft/TypeScript/issues/31535
+declare const TextEncoder: any;
+declare const TextDecoder: any;
+
+// Global symbol available in browsers only
+declare const self: Record<string, any> | undefined
+
 // prettier-ignore
 export type TypedArray = Int8Array | Uint8ClampedArray | Uint8Array |
   Uint16Array | Int16Array | Uint32Array | Int32Array;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
         "strict": true,
         "outDir": "lib",
         "target": "es2020",
+        "lib": ["es2020"], // Set explicitly to remove DOM
         "module": "commonjs",
         "noUnusedLocals": true,
         "esModuleInterop": true,


### PR DESCRIPTION
This is a follow-up on https://github.com/paulmillr/noble-hashes/issues/9. Both `self` and `TextEncoder` are declared in DOM. But we can easily declare them in a way that is aware of both DOM and non-DOM environments.