### PR TITLE
Fixes for ESM imports (.js ext, type: module)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 /build/
-/lib
+/lib/**/*.js
+/lib/**/*.ts

--- a/lib/esm/package.json
+++ b/lib/esm/package.json
@@ -1,0 +1,3 @@
+{
+	"type": "module"
+}

--- a/src/_blake2.ts
+++ b/src/_blake2.ts
@@ -1,4 +1,4 @@
-import { assertNumber, Hash, Input, toBytes, u32 } from './utils';
+import { assertNumber, Hash, Input, toBytes, u32 } from './utils.js';
 // prettier-ignore
 export const SIGMA = new Uint8Array([
   0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,

--- a/src/_sha2.ts
+++ b/src/_sha2.ts
@@ -1,4 +1,4 @@
-import { Hash, createView, Input, toBytes } from './utils';
+import { Hash, createView, Input, toBytes } from './utils.js';
 
 // Polyfill for Safari 14
 function setBigUint64(view: DataView, byteOffset: number, value: bigint, isLE: boolean): void {

--- a/src/blake2b.ts
+++ b/src/blake2b.ts
@@ -1,6 +1,6 @@
-import * as blake2 from './_blake2';
-import * as u64 from './_u64';
-import { toBytes, u32, wrapConstructorWithOpts } from './utils';
+import * as blake2 from './_blake2.js';
+import * as u64 from './_u64.js';
+import { toBytes, u32, wrapConstructorWithOpts } from './utils.js';
 
 // Same as SHA-512 but LE
 // prettier-ignore

--- a/src/blake2s.ts
+++ b/src/blake2s.ts
@@ -1,6 +1,6 @@
-import * as u64 from './_u64';
-import * as blake2 from './_blake2';
-import { rotr, toBytes, wrapConstructorWithOpts, u32 } from './utils';
+import * as u64 from './_u64.js';
+import * as blake2 from './_blake2.js';
+import { rotr, toBytes, wrapConstructorWithOpts, u32 } from './utils.js';
 
 // Initial state:
 // first 32 bits of the fractional parts of the square roots of the first 8 primes 2..19)

--- a/src/blake3.ts
+++ b/src/blake3.ts
@@ -1,7 +1,7 @@
-import * as u64 from './_u64';
-import * as blake2 from './_blake2';
-import * as blake2s from './blake2s';
-import { Input, u8, u32, toBytes, wrapConstructorWithOpts, assertNumber, HashXOF } from './utils';
+import * as u64 from './_u64.js';
+import * as blake2 from './_blake2.js';
+import * as blake2s from './blake2s.js';
+import { Input, u8, u32, toBytes, wrapConstructorWithOpts, assertNumber, HashXOF } from './utils.js';
 
 // Flag bitset
 enum Flags {

--- a/src/hkdf.ts
+++ b/src/hkdf.ts
@@ -1,8 +1,8 @@
 // prettier-ignore
 import {
   assertHash, assertNumber, CHash, Input, toBytes
-} from './utils';
-import { hmac } from './hmac';
+} from './utils.js';
+import { hmac } from './hmac.js';
 
 // HKDF (RFC 5869)
 // HKDF-Extract(IKM, salt) -> PRK NOTE: arguments position differs from spec (IKM is first one, since it is not optional)

--- a/src/hmac.ts
+++ b/src/hmac.ts
@@ -1,4 +1,4 @@
-import { assertHash, Hash, CHash, Input, toBytes } from './utils';
+import { assertHash, Hash, CHash, Input, toBytes } from './utils.js';
 // HMAC (RFC 2104)
 class HMAC<T extends Hash<T>> extends Hash<HMAC<T>> {
   oHash: T;

--- a/src/pbkdf2.ts
+++ b/src/pbkdf2.ts
@@ -1,8 +1,8 @@
-import { hmac } from './hmac';
+import { hmac } from './hmac.js';
 // prettier-ignore
 import {
   Hash, CHash, Input, createView, toBytes, assertNumber, assertHash, checkOpts, asyncLoop
-} from './utils';
+} from './utils.js';
 
 // PBKDF (RFC 2898)
 export type Pbkdf2Opt = {

--- a/src/ripemd160.ts
+++ b/src/ripemd160.ts
@@ -1,6 +1,6 @@
-import { SHA2 } from './_sha2';
+import { SHA2 } from './_sha2.js';
 
-import { wrapConstructor } from './utils';
+import { wrapConstructor } from './utils.js';
 
 // https://homes.esat.kuleuven.be/~bosselae/ripemd160.html
 // https://homes.esat.kuleuven.be/~bosselae/ripemd160/pdf/AB-9601/AB-9601.pdf

--- a/src/scrypt.ts
+++ b/src/scrypt.ts
@@ -1,6 +1,6 @@
-import { sha256 } from './sha256';
-import { pbkdf2 } from './pbkdf2';
-import { assertNumber, asyncLoop, checkOpts, Input, u32 } from './utils';
+import { sha256 } from './sha256.js';
+import { pbkdf2 } from './pbkdf2.js';
+import { assertNumber, asyncLoop, checkOpts, Input, u32 } from './utils.js';
 
 // Left rotate for uint32
 const rotl = (a: number, b: number) => (a << b) | (a >>> (32 - b));

--- a/src/sha256.ts
+++ b/src/sha256.ts
@@ -1,5 +1,5 @@
-import { SHA2 } from './_sha2';
-import { rotr, wrapConstructor } from './utils';
+import { SHA2 } from './_sha2.js';
+import { rotr, wrapConstructor } from './utils.js';
 
 // Choice: a ? b : c
 const Chi = (a: number, b: number, c: number) => (a & b) ^ (~a & c);

--- a/src/sha3-addons.ts
+++ b/src/sha3-addons.ts
@@ -1,5 +1,5 @@
-import { Input, toBytes, wrapConstructorWithOpts, assertNumber, u32, Hash, HashXOF } from './utils';
-import { Keccak, ShakeOpts } from './sha3';
+import { Input, toBytes, wrapConstructorWithOpts, assertNumber, u32, Hash, HashXOF } from './utils.js';
+import { Keccak, ShakeOpts } from './sha3.js';
 // cSHAKE && KMAC (NIST SP800-185)
 function leftEncode(n: number): Uint8Array {
   const res = [n & 0xff];

--- a/src/sha3.ts
+++ b/src/sha3.ts
@@ -1,4 +1,4 @@
-import * as u64 from './_u64';
+import * as u64 from './_u64.js';
 import {
   Hash,
   u32,
@@ -8,7 +8,7 @@ import {
   wrapConstructorWithOpts,
   assertNumber,
   HashXOF,
-} from './utils';
+} from './utils.js';
 
 // Various per round constants calculations
 const [SHA3_PI, SHA3_ROTL, _SHA3_IOTA]: [number[], number[], bigint[]] = [[], [], []];

--- a/src/sha512.ts
+++ b/src/sha512.ts
@@ -1,6 +1,6 @@
-import { SHA2 } from './_sha2';
-import * as u64 from './_u64';
-import { wrapConstructor } from './utils';
+import { SHA2 } from './_sha2.js';
+import * as u64 from './_u64.js';
+import { wrapConstructor } from './utils.js';
 
 // Round contants (first 32 bits of the fractional parts of the cube roots of the first 80 primes 2..409):
 // prettier-ignore


### PR DESCRIPTION
Closes https://github.com/paulmillr/noble-hashes/issues/17

- Adds explicit `.js` extensions to relative imports
- Add type: module package.json to lib/esm/