### PR TITLE
Fix hash-wasm benchmarks for PBKDF2-HMAC-SHA512

### DIFF
--- a/test/benchmark/kdf.js
+++ b/test/benchmark/kdf.js
@@ -63,7 +63,7 @@ const KDF = {
         password: 'password',
         salt,
         iterations: iters,
-        hashLength: 32,
+        hashLength: 64,
         hashFunction: wasm.createSHA512(),
         outputType: 'binary',
       }),

--- a/test/benchmark/kdf.js
+++ b/test/benchmark/kdf.js
@@ -43,6 +43,15 @@ const KDF_ITERS = [
 const KDF = {
   'PBKDF2-HMAC-SHA256': {
     node: (iters) => crypto.pbkdf2Sync(password, salt, iters, 32, 'sha256'),
+    'hash-wasm': (iters) =>
+      wasm.pbkdf2({
+        password: 'password',
+        salt,
+        iterations: iters,
+        hashLength: 32,
+        hashFunction: wasm.createSHA256(),
+        outputType: 'binary',
+      }),
     stablelib: (iters) => stablePBKDF2(stable256.SHA256, password, salt, iters, 32),
     noble: (iters) => pbkdf2(sha256, password, salt, { c: iters, dkLen: 32 }),
     'noble (async)': (iters) => pbkdf2Async(sha256, password, salt, { c: iters, dkLen: 32 }),


### PR DESCRIPTION
This fixes the output length for the `hash-wasm` implementation to 64 bytes.

The difference between the broken code before and now (both SHA-512) is in the order of 1-3 %.

```
PBKDF2-HMAC-SHA512 512 hash-wasm (broken 32 bytes hashLength) x 869 ops/sec @ 1ms/op
PBKDF2-HMAC-SHA512 512 hash-wasm x 883 ops/sec @ 1ms/op
PBKDF2-HMAC-SHA512 1024 hash-wasm (broken 32 bytes hashLength) x 475 ops/sec @ 2ms/op
PBKDF2-HMAC-SHA512 1024 hash-wasm x 478 ops/sec @ 2ms/op
PBKDF2-HMAC-SHA512 2048 hash-wasm (broken 32 bytes hashLength) x 240 ops/sec @ 4ms/op
PBKDF2-HMAC-SHA512 2048 hash-wasm x 245 ops/sec @ 4ms/op
PBKDF2-HMAC-SHA512 16384 hash-wasm (broken 32 bytes hashLength) x 32 ops/sec @ 31ms/op
PBKDF2-HMAC-SHA512 16384 hash-wasm x 32 ops/sec @ 31ms/op
PBKDF2-HMAC-SHA512 65536 hash-wasm (broken 32 bytes hashLength) x 8 ops/sec @ 123ms/op
PBKDF2-HMAC-SHA512 65536 hash-wasm x 7 ops/sec @ 128ms/op
PBKDF2-HMAC-SHA512 262144 hash-wasm (broken 32 bytes hashLength) x 2 ops/sec @ 495ms/op
PBKDF2-HMAC-SHA512 262144 hash-wasm x 2 ops/sec @ 497ms/op
```

It also adds `hash-wasm` to PBKDF2-HMAC-SHA256 because we can.