### PR TITLE
Remove dangling comma in esm/package.json

### DIFF
--- a/esm/package.json
+++ b/esm/package.json
@@ -2,6 +2,6 @@
   "type": "module",
   "browser": {
     "crypto": false,
-    "./crypto": "./esm/cryptoBrowser.js",
+    "./crypto": "./esm/cryptoBrowser.js"
   }
 }


### PR DESCRIPTION
It breaks rollup, e.g

```
[!] (plugin commonjs) SyntaxError: Unexpected token } in JSON at position 102
SyntaxError: Unexpected token } in JSON at position 102
    at JSON.parse (<anonymous>)
```