### PR TITLE
Add TS types field to exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
       "default": "./index.js"
     },
     "./crypto": {
+      "types": "./crypto.d.ts",
       "browser": {
         "import": "./esm/cryptoBrowser.js",
         "default": "./cryptoBrowser.js"
@@ -55,10 +56,12 @@
       "default": "./crypto.js"
     },
     "./_assert": {
+      "types": "./_assert.d.ts",
       "import": "./esm/_assert.js",
       "default": "./_assert.js"
     },
     "./_sha2": {
+      "types": "./_sha2.d.ts",
       "import": "./esm/_sha2.js",
       "default": "./_sha2.js"
     },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "typescript": "4.7.3"
   },
   "exports": {
-    "./index": {
+    ".": {
+      "types": "./index.d.ts",
       "import": "./esm/index.js",
       "default": "./index.js"
     },
@@ -62,80 +63,80 @@
       "default": "./_sha2.js"
     },
     "./blake2b": {
+      "types": "./blake2b.d.ts",
       "import": "./esm/blake2b.js",
       "default": "./blake2b.js"
     },
-    "./blake2b.d.ts": "blake2b.d.ts",
     "./blake2s": {
+      "types": "./blake2s.d.ts",
       "import": "./esm/blake2s.js",
       "default": "./blake2s.js"
     },
-    "./blake2s.d.ts": "blake2s.d.ts",
     "./blake3": {
+      "types": "./blake3.d.ts",
       "import": "./esm/blake3.js",
       "default": "./blake3.js"
     },
-    "./blake3.d.ts": "blake3.d.ts",
     "./eskdf": {
+      "types": "./eskdf.d.ts",
       "import": "./esm/eskdf.js",
       "default": "./eskdf.js"
     },
-    "./eskdf.d.ts": "eskdf.d.ts",
     "./hkdf": {
+      "types": "./hkdf.d.ts",
       "import": "./esm/hkdf.js",
       "default": "./hkdf.js"
     },
-    "./hkdf.d.ts": "hkdf.d.ts",
     "./hmac": {
+      "types": "./hmac.d.ts",
       "import": "./esm/hmac.js",
       "default": "./hmac.js"
     },
-    "./hmac.d.ts": "hmac.d.ts",
     "./pbkdf2": {
+      "types": "./pbkdf2.d.ts",
       "import": "./esm/pbkdf2.js",
       "default": "./pbkdf2.js"
     },
-    "./pbkdf2.d.ts": "pbkdf2.d.ts",
     "./ripemd160": {
+      "types": "./ripemd160.d.ts",
       "import": "./esm/ripemd160.js",
       "default": "./ripemd160.js"
     },
-    "./ripemd160.d.ts": "ripemd160.d.ts",
     "./scrypt": {
+      "types": "./scrypt.d.ts",
       "import": "./esm/scrypt.js",
       "default": "./scrypt.js"
     },
-    "./scrypt.d.ts": "scrypt.d.ts",
     "./sha1": {
+      "types": "./sha1.d.ts",
       "import": "./esm/sha1.js",
       "default": "./sha1.js"
     },
-    "./sha1.d.ts": "sha1.d.ts",
     "./sha3-addons": {
+      "types": "./sha3-addons.d.ts",
       "import": "./esm/sha3-addons.js",
       "default": "./sha3-addons.js"
     },
-    "./sha3-addons.d.ts": "sha3-addons.d.ts",
     "./sha3": {
+      "types": "./sha3.d.ts",
       "import": "./esm/sha3.js",
       "default": "./sha3.js"
     },
-    "./sha3.d.ts": "sha3.d.ts",
     "./sha256": {
+      "types": "./sha256.d.ts",
       "import": "./esm/sha256.js",
       "default": "./sha256.js"
     },
-    "./sha256.d.ts": "sha256.d.ts",
     "./sha512": {
+      "types": "./sha512.d.ts",
       "import": "./esm/sha512.js",
       "default": "./sha512.js"
     },
-    "./sha512.d.ts": "sha512.d.ts",
     "./utils": {
+      "types": "./utils.d.ts",
       "import": "./esm/utils.js",
       "default": "./utils.js"
-    },
-    "./utils.d.ts": "utils.d.ts"
+    }
   },
   "keywords": [
     "sha",


### PR DESCRIPTION
This PR add the "types" field to the export map for [TS usage](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing). This is a similar PR as the recent one to [noble-ed25519](https://github.com/paulmillr/noble-ed25519/pull/66)

Additionally the `/index` export was renamed to `.` - this aligns with [noble-ed25519](https://github.com/paulmillr/noble-ed25519/blob/731d8faea7752af987ca7d6f3f982644ca45b80f/package.json#L61) & [noble-secp256k1](https://github.com/paulmillr/noble-secp256k1/blob/5bea862db522d0147e512f7e3ac7425bd698d3e4/package.json#L65). (Obviously it is less useful here since it is not meant to be used)

Looking through this, I believe the `_assert` & `_sha2` exports can be removed. Removing this would align with other internal files, e.g. `_u64` that don't appear since they are not accessed externally by library users, these are only for internal access. (This PR does not include that, I only moved the types without introducing something new)

We would need a similar, obviously much smaller, PR to [noble-secp256k1](https://github.com/paulmillr/noble-secp256k1/blob/5bea862db522d0147e512f7e3ac7425bd698d3e4/package.json#L69) as well.