### PR TITLE
Ensure blake3 inputs are immutable

### DIFF
--- a/src/blake3.ts
+++ b/src/blake3.ts
@@ -70,9 +70,10 @@ class BLAKE3 extends BLAKE2<BLAKE3> implements HashXOF<BLAKE3> {
       this.IV = u32(context_key);
       this.flags = flags | Flags.DERIVE_KEY_MATERIAL;
     } else {
-      this.IV = IV.slice();
+      this.IV = IV;
       this.flags = flags;
     }
+    this.IV = this.IV.slice();
     this.state = this.IV.slice();
     this.bufferOut = u8(this.bufferOut32);
   }

--- a/test/blake.test.js
+++ b/test/blake.test.js
@@ -119,4 +119,42 @@ should('Blake3 XOF', () => {
   assert.deepStrictEqual(concatBytes(...out), bigOut, 'xof check against fixed size');
 });
 
+should('BLAKE2b inputs are immuatable', () => {
+  const msg = new Uint8Array([1,2,3,4]);
+  const key = new Uint8Array([1,2,3,4]);
+  const pers = new Uint8Array([1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8]);
+  const salt = new Uint8Array([1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8]);
+  blake2b(msg);
+  blake2b(msg, { key, salt, personalization: pers });
+  assert.deepStrictEqual(msg, new Uint8Array([1,2,3,4]));
+  assert.deepStrictEqual(key, new Uint8Array([1,2,3,4]));
+  assert.deepStrictEqual(pers, new Uint8Array([1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8]));
+  assert.deepStrictEqual(salt, new Uint8Array([1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8]));
+})
+
+should('BLAKE2s inputs are immuatable', () => {
+  const msg = new Uint8Array([1,2,3,4]);
+  const key = new Uint8Array([1,2,3,4]);
+  const pers = new Uint8Array([1,2,3,4,5,6,7,8]);
+  const salt = new Uint8Array([1,2,3,4,5,6,7,8]);
+  blake2s(msg);
+  blake2s(msg, { key, salt, personalization: pers });
+  assert.deepStrictEqual(msg, new Uint8Array([1,2,3,4]));
+  assert.deepStrictEqual(key, new Uint8Array([1,2,3,4]));
+  assert.deepStrictEqual(pers, new Uint8Array([1,2,3,4,5,6,7,8]));
+  assert.deepStrictEqual(salt, new Uint8Array([1,2,3,4,5,6,7,8]));
+})
+
+should('BLAKE3 inputs are immuatable', () => {
+  const msg = new Uint8Array([1,2,3,4]);
+  const ctx = new Uint8Array([1,2,3,4]);
+  const key = new Uint8Array([1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8]);
+  blake3(msg);
+  blake3(msg, { key });
+  blake3(msg, { context: ctx });
+  assert.deepStrictEqual(msg, new Uint8Array([1,2,3,4]));
+  assert.deepStrictEqual(ctx, new Uint8Array([1,2,3,4]));
+  assert.deepStrictEqual(key, new Uint8Array([1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8]));
+})
+
 if (require.main === module) should.run();

--- a/test/blake.test.js
+++ b/test/blake.test.js
@@ -120,41 +120,46 @@ should('Blake3 XOF', () => {
 });
 
 should('BLAKE2b inputs are immuatable', () => {
-  const msg = new Uint8Array([1,2,3,4]);
-  const key = new Uint8Array([1,2,3,4]);
-  const pers = new Uint8Array([1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8]);
-  const salt = new Uint8Array([1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8]);
-  blake2b(msg);
+  const msg = new Uint8Array([1, 2, 3, 4]);
+  const key = new Uint8Array([1, 2, 3, 4]);
+  const pers = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8]);
+  const salt = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8]);
   blake2b(msg, { key, salt, personalization: pers });
-  assert.deepStrictEqual(msg, new Uint8Array([1,2,3,4]));
-  assert.deepStrictEqual(key, new Uint8Array([1,2,3,4]));
-  assert.deepStrictEqual(pers, new Uint8Array([1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8]));
-  assert.deepStrictEqual(salt, new Uint8Array([1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8]));
-})
+  assert.deepStrictEqual(msg, new Uint8Array([1, 2, 3, 4]));
+  assert.deepStrictEqual(key, new Uint8Array([1, 2, 3, 4]));
+  assert.deepStrictEqual(pers, new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8]));
+  assert.deepStrictEqual(salt, new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8]));
+});
 
 should('BLAKE2s inputs are immuatable', () => {
-  const msg = new Uint8Array([1,2,3,4]);
-  const key = new Uint8Array([1,2,3,4]);
-  const pers = new Uint8Array([1,2,3,4,5,6,7,8]);
-  const salt = new Uint8Array([1,2,3,4,5,6,7,8]);
-  blake2s(msg);
+  const msg = new Uint8Array([1, 2, 3, 4]);
+  const key = new Uint8Array([1, 2, 3, 4]);
+  const pers = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+  const salt = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
   blake2s(msg, { key, salt, personalization: pers });
-  assert.deepStrictEqual(msg, new Uint8Array([1,2,3,4]));
-  assert.deepStrictEqual(key, new Uint8Array([1,2,3,4]));
-  assert.deepStrictEqual(pers, new Uint8Array([1,2,3,4,5,6,7,8]));
-  assert.deepStrictEqual(salt, new Uint8Array([1,2,3,4,5,6,7,8]));
-})
+  assert.deepStrictEqual(msg, new Uint8Array([1, 2, 3, 4]));
+  assert.deepStrictEqual(key, new Uint8Array([1, 2, 3, 4]));
+  assert.deepStrictEqual(pers, new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]));
+  assert.deepStrictEqual(salt, new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]));
+});
 
 should('BLAKE3 inputs are immuatable', () => {
-  const msg = new Uint8Array([1,2,3,4]);
-  const ctx = new Uint8Array([1,2,3,4]);
-  const key = new Uint8Array([1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8]);
-  blake3(msg);
+  const msg = new Uint8Array([1, 2, 3, 4]);
+  const ctx = new Uint8Array([1, 2, 3, 4]);
+  const key = new Uint8Array([
+    1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8,
+  ]);
   blake3(msg, { key });
   blake3(msg, { context: ctx });
-  assert.deepStrictEqual(msg, new Uint8Array([1,2,3,4]));
-  assert.deepStrictEqual(ctx, new Uint8Array([1,2,3,4]));
-  assert.deepStrictEqual(key, new Uint8Array([1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8]));
-})
+  assert.deepStrictEqual(msg, new Uint8Array([1, 2, 3, 4]));
+  assert.deepStrictEqual(ctx, new Uint8Array([1, 2, 3, 4]));
+  assert.deepStrictEqual(
+    key,
+    new Uint8Array([
+      1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7,
+      8,
+    ])
+  );
+});
 
 if (require.main === module) should.run();


### PR DESCRIPTION
Fixes #50 

- ensures the blake3 IV is copied, not referenced
- adds tests ensuring inputs are immutable for all the blake family hashing functions

As discussed in #50, I tried to spot if this issue is anywhere else. Looking where `toBytes` is used doesn't really help as a) it's used all over the place, and b) it doesn't reveal if elsewhere in the code a referenced input is mutated.

Best thing is to add similar tests as I've done for every hash function. But that's a job for a rainy day ;)