### PR TITLE
Specify supported Node.js version range in manifest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,9 @@
         "micro-should": "0.4.0",
         "prettier": "2.8.4",
         "typescript": "5.0.2"
+      },
+      "engines": {
+        "node": "16.x || >= 18.0.0"
       }
     },
     "node_modules/micro-bmark": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "esm",
     "src/*.ts"
   ],
+  "engines": {
+    "node": "16.x || >= 18.0.0"
+  },
   "scripts": {
     "bench": "node test/benchmark/index.js noble",
     "bench:all": "node test/benchmark/index.js",


### PR DESCRIPTION
As per [this comment](https://github.com/ethereum/js-ethereum-cryptography/pull/77#issuecomment-1530152915), this package has already dropped support for Node.js version 14.

This adds that to the package manifest to expose this information to tooling and users in a standardized way.