### PR TITLE
ci: test nodejs v16/v18/v20

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,14 +3,17 @@ name: Node CI
 on: [push, pull_request]
 jobs:
   test:
-    name: v20 @ ubuntu-latest
+    name: node @ ubuntu-latest
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x, 20.x]
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node }}
       uses: actions/setup-node@v3
       with:
-        node-version: 20
+        node-version: ${{ matrix.node-version }}
     - run: npm install
     - run: npm run build --if-present
     - run: npm test


### PR DESCRIPTION
This extends the nodejs CI workflow to test using each of the supported major Node.js versions, to reduce the risk of future regressions causing unexpected differences between runtime versions.


[Sample run](https://github.com/legobeat/noble-hashes/actions/runs/4857131666)