### PR TITLE
setup size-limit as other library tools

### DIFF
--- a/size/.size-limit.cjs
+++ b/size/.size-limit.cjs
@@ -1,0 +1,18 @@
+// prettier-ignore
+module.exports = [
+  ['blake2b', 'blake2b'], ['blake2s', 'blake2s'], ['blake3', 'blake3'], ['hmac', 'hmac'],
+  ['hkdf', 'hkdf'], ['pbkdf2', 'pbkdf2'], ['pbkdf2', 'pbkdf2Async'], ['ripemd160', 'ripemd160'],
+  ['scrypt', 'scrypt'], ['scrypt', 'scryptAsync'], ['sha256', 'sha256'], ['sha512', 'sha512'],
+  ['sha1', 'sha1'], ['sha3', 'sha3_224'], ['sha3', 'sha3_256'], ['sha3', 'sha3_384'],
+  ['sha3', 'sha3_512'], ['sha3', 'keccakP'], ['sha3', 'keccak_256'], ['sha3', 'keccak_384'],
+  ['sha3', 'keccak_512'], ['sha3-addons', 'cshake128'], ['sha3-addons', 'cshake256'],
+  ['sha3-addons', 'kmac128'], ['sha3-addons', 'kmac256'], ['sha3-addons', 'k12'],
+  ['sha3-addons', 'm14'], ['argon2', 'argon2id'], ['eskdf', 'eskdf'],
+].map(([filename, imports]) => ({
+  name: `${imports} from ${filename}`,
+  path: `../esm/${filename}.js`,
+  import: `{ ${imports} }`,
+  running: false,
+  ignore: ['@noble/hashes/crypto'],
+}));
+

--- a/size/package.json
+++ b/size/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "size-limit",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Used to check library size",
+  "main": "input.js",
+  "keywords": [],
+  "type": "module",
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "@size-limit/preset-big-lib": "^8.2.4",
+    "size-limit": "^8.2.4"
+  },
+  "scripts": {
+    "size": "size-limit"
+  }
+}


### PR DESCRIPTION
Hello

I added `size-limit` as a separate package to test bundle size and tree-shaking

Current master sizes:

```npm run size

> size-limit@1.0.0 size
> size-limit

✔ Adding to empty webpack project
✔ Running JS in headless Chrome
  
  blake2b from blake2b
  Size:         3 kB  with all dependencies, minified and gzipped
  Loading time: 59 ms on slow 3G
  
  blake2s from blake2s
  Size:         2.75 kB with all dependencies, minified and gzipped
  Loading time: 54 ms   on slow 3G
  
  blake3 from blake3
  Size:         4.22 kB with all dependencies, minified and gzipped
  Loading time: 83 ms   on slow 3G
  
  hmac from hmac
  Size:         1.03 kB with all dependencies, minified and gzipped
  Loading time: 21 ms   on slow 3G
  
  hkdf from hkdf
  Size:         1.25 kB with all dependencies, minified and gzipped
  Loading time: 25 ms   on slow 3G
  
  pbkdf2 from pbkdf2
  Size:         1.47 kB with all dependencies, minified and gzipped
  Loading time: 29 ms   on slow 3G
  
  pbkdf2Async from pbkdf2
  Size:         1.54 kB with all dependencies, minified and gzipped
  Loading time: 31 ms   on slow 3G
  
  ripemd160 from ripemd160
  Size:         2.15 kB with all dependencies, minified and gzipped
  Loading time: 42 ms   on slow 3G
  
  scrypt from scrypt
  Size:         4.32 kB with all dependencies, minified and gzipped
  Loading time: 85 ms   on slow 3G
  
  scryptAsync from scrypt
  Size:         4.39 kB with all dependencies, minified and gzipped
  Loading time: 86 ms   on slow 3G
  
  sha256 from sha256
  Size:         2.45 kB with all dependencies, minified and gzipped
  Loading time: 48 ms   on slow 3G
  
  sha512 from sha512
  Size:         4.09 kB with all dependencies, minified and gzipped
  Loading time: 80 ms   on slow 3G
  
  sha1 from sha1
  Size:         1.82 kB with all dependencies, minified and gzipped
  Loading time: 36 ms   on slow 3G
  
  sha3_224 from sha3
  Size:         2.06 kB with all dependencies, minified and gzipped
  Loading time: 41 ms   on slow 3G
  
  sha3_256 from sha3
  Size:         2.06 kB with all dependencies, minified and gzipped
  Loading time: 41 ms   on slow 3G
  
  sha3_384 from sha3
  Size:         2.06 kB with all dependencies, minified and gzipped
  Loading time: 41 ms   on slow 3G
  
  sha3_512 from sha3
  Size:         2.06 kB with all dependencies, minified and gzipped
  Loading time: 41 ms   on slow 3G
  
  keccakP from sha3
  Size:         2.06 kB with all dependencies, minified and gzipped
  Loading time: 41 ms   on slow 3G
  
  keccak_256 from sha3
  Size:         2.06 kB with all dependencies, minified and gzipped
  Loading time: 41 ms   on slow 3G
  
  keccak_384 from sha3
  Size:         2.06 kB with all dependencies, minified and gzipped
  Loading time: 41 ms   on slow 3G
  
  keccak_512 from sha3
  Size:         2.06 kB with all dependencies, minified and gzipped
  Loading time: 41 ms   on slow 3G
  
  cshake128 from sha3-addons
  Size:         2.32 kB with all dependencies, minified and gzipped
  Loading time: 46 ms   on slow 3G
  
  cshake256 from sha3-addons
  Size:         2.32 kB with all dependencies, minified and gzipped
  Loading time: 46 ms   on slow 3G
  
  kmac128 from sha3-addons
  Size:         2.5 kB with all dependencies, minified and gzipped
  Loading time: 49 ms  on slow 3G
  
  kmac256 from sha3-addons
  Size:         2.5 kB with all dependencies, minified and gzipped
  Loading time: 49 ms  on slow 3G
  
  k12 from sha3-addons
  Size:         2.51 kB with all dependencies, minified and gzipped
  Loading time: 50 ms   on slow 3G
  
  m14 from sha3-addons
  Size:         2.51 kB with all dependencies, minified and gzipped
  Loading time: 50 ms   on slow 3G
  
  argon2id from argon2
  Size:         4.9 kB with all dependencies, minified and gzipped
  Loading time: 96 ms  on slow 3G
  
  eskdf from eskdf
  Size:         5.43 kB with all dependencies, minified and gzipped
  Loading time: 107 ms  on slow 3G
```
