### PR TITLE
Tweak size

### DIFF
--- a/esm/package.json
+++ b/esm/package.json
@@ -1,5 +1,6 @@
 {
   "type": "module",
+  "sideEffects": false,
   "browser": {
     "node:crypto": false
   },

--- a/esm/package.json
+++ b/esm/package.json
@@ -1,6 +1,6 @@
 {
   "type": "module",
-  "sideEffects": false,
+  "sideEffects": ["./_big-endian-check.js"],
   "browser": {
     "node:crypto": false
   },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "engines": {
     "node": ">= 16"
   },
-  "sideEffects": false,
+  "sideEffects": ["./esm/_big-endian-check.js"],
   "exports": {
     ".": {
       "types": "./index.d.ts",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "engines": {
     "node": ">= 16"
   },
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./index.d.ts",

--- a/src/_assert.ts
+++ b/src/_assert.ts
@@ -37,11 +37,7 @@ function output(out: any, instance: any) {
   }
 }
 
-export {
-  number,
-  bool,
-  bytes,
-  hash,
-  exists,
-  output,
-};
+export { number, bool, bytes, hash, exists, output };
+
+const assert = { number, bool, bytes, hash, exists, output };
+export default assert;

--- a/src/_assert.ts
+++ b/src/_assert.ts
@@ -1,12 +1,12 @@
-export function number(n: number) {
+function number(n: number) {
   if (!Number.isSafeInteger(n) || n < 0) throw new Error(`Wrong positive integer: ${n}`);
 }
 
-export function bool(b: boolean) {
+function bool(b: boolean) {
   if (typeof b !== 'boolean') throw new Error(`Expected boolean, not ${b}`);
 }
 
-export function bytes(b: Uint8Array | undefined, ...lengths: number[]) {
+function bytes(b: Uint8Array | undefined, ...lengths: number[]) {
   if (!(b instanceof Uint8Array)) throw new Error('Expected Uint8Array');
   if (lengths.length > 0 && !lengths.includes(b.length))
     throw new Error(`Expected Uint8Array of length ${lengths}, not of length=${b.length}`);
@@ -18,18 +18,18 @@ type Hash = {
   outputLen: number;
   create: any;
 };
-export function hash(hash: Hash) {
+function hash(hash: Hash) {
   if (typeof hash !== 'function' || typeof hash.create !== 'function')
     throw new Error('Hash should be wrapped by utils.wrapConstructor');
   number(hash.outputLen);
   number(hash.blockLen);
 }
 
-export function exists(instance: any, checkFinished = true) {
+function exists(instance: any, checkFinished = true) {
   if (instance.destroyed) throw new Error('Hash instance has been destroyed');
   if (checkFinished && instance.finished) throw new Error('Hash#digest() has already been called');
 }
-export function output(out: any, instance: any) {
+function output(out: any, instance: any) {
   bytes(out);
   const min = instance.outputLen;
   if (out.length < min) {
@@ -37,7 +37,7 @@ export function output(out: any, instance: any) {
   }
 }
 
-const assert = {
+export {
   number,
   bool,
   bytes,
@@ -45,5 +45,3 @@ const assert = {
   exists,
   output,
 };
-
-export default assert;

--- a/src/_big-endian-check.ts
+++ b/src/_big-endian-check.ts
@@ -1,0 +1,5 @@
+import { isLE } from './utils.js';
+
+// big-endian hardware is rare. Just in case someone still decides to run hashes:
+// early-throw an error because we don't support BE yet.
+if (!isLE) throw new Error('Non little-endian hardware is not supported');

--- a/src/_blake2.ts
+++ b/src/_blake2.ts
@@ -2,7 +2,7 @@ import assert from './_assert.js';
 import { Hash, Input, toBytes, u32 } from './utils.js';
 // For BLAKE2b, the two extra permutations for rounds 10 and 11 are SIGMA[10..11] = SIGMA[0..1].
 // prettier-ignore
-export const SIGMA = new Uint8Array([
+export const SIGMA = /*#__PURE__*/ new Uint8Array([
   0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
   14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3,
   11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4,

--- a/src/_blake2.ts
+++ b/src/_blake2.ts
@@ -1,4 +1,4 @@
-import assert from './_assert.js';
+import * as assert from './_assert.js';
 import { Hash, Input, toBytes, u32 } from './utils.js';
 // For BLAKE2b, the two extra permutations for rounds 10 and 11 are SIGMA[10..11] = SIGMA[0..1].
 // prettier-ignore

--- a/src/_sha2.ts
+++ b/src/_sha2.ts
@@ -1,3 +1,4 @@
+import './_big-endian-check.js'
 import * as assert from './_assert.js';
 import { Hash, createView, Input, toBytes } from './utils.js';
 

--- a/src/_sha2.ts
+++ b/src/_sha2.ts
@@ -1,4 +1,4 @@
-import assert from './_assert.js';
+import * as assert from './_assert.js';
 import { Hash, createView, Input, toBytes } from './utils.js';
 
 // Polyfill for Safari 14

--- a/src/_u64.ts
+++ b/src/_u64.ts
@@ -2,12 +2,12 @@ const U32_MASK64 = /*#__PURE__*/ BigInt(2 ** 32 - 1);
 const _32n = /*#__PURE__*/ BigInt(32);
 
 // We are not using BigUint64Array, because they are extremely slow as per 2022
-export function fromBig(n: bigint, le = false) {
+function fromBig(n: bigint, le = false) {
   if (le) return { h: Number(n & U32_MASK64), l: Number((n >> _32n) & U32_MASK64) };
   return { h: Number((n >> _32n) & U32_MASK64) | 0, l: Number(n & U32_MASK64) | 0 };
 }
 
-export function split(lst: bigint[], le = false) {
+function split(lst: bigint[], le = false) {
   let Ah = new Uint32Array(lst.length);
   let Al = new Uint32Array(lst.length);
   for (let i = 0; i < lst.length; i++) {
@@ -17,7 +17,7 @@ export function split(lst: bigint[], le = false) {
   return [Ah, Al];
 }
 
-export const toBig = (h: number, l: number) => (BigInt(h >>> 0) << _32n) | BigInt(l >>> 0);
+const toBig = (h: number, l: number) => (BigInt(h >>> 0) << _32n) | BigInt(l >>> 0);
 // for Shift in [0, 32)
 const shrSH = (h: number, l: number, s: number) => h >>> s;
 const shrSL = (h: number, l: number, s: number) => (h << (32 - s)) | (l >>> s);
@@ -40,7 +40,7 @@ const rotlBL = (h: number, l: number, s: number) => (h << (s - 32)) | (l >>> (64
 // JS uses 32-bit signed integers for bitwise operations which means we cannot
 // simple take carry out of low bit sum by shift, we need to use division.
 // Removing "export" has 5% perf penalty -_-
-export function add(Ah: number, Al: number, Bh: number, Bl: number) {
+function add(Ah: number, Al: number, Bh: number, Bl: number) {
   const l = (Al >>> 0) + (Bl >>> 0);
   return { h: (Ah + Bh + ((l / 2 ** 32) | 0)) | 0, l: l | 0 };
 }
@@ -58,7 +58,7 @@ const add5H = (low: number, Ah: number, Bh: number, Ch: number, Dh: number, Eh: 
   (Ah + Bh + Ch + Dh + Eh + ((low / 2 ** 32) | 0)) | 0;
 
 // prettier-ignore
-const u64 = {
+export {
   fromBig, split, toBig,
   shrSH, shrSL,
   rotrSH, rotrSL, rotrBH, rotrBL,
@@ -66,4 +66,3 @@ const u64 = {
   rotlSH, rotlSL, rotlBH, rotlBL,
   add, add3L, add3H, add4L, add4H, add5H, add5L,
 };
-export default u64;

--- a/src/_u64.ts
+++ b/src/_u64.ts
@@ -1,5 +1,5 @@
-const U32_MASK64 = BigInt(2 ** 32 - 1);
-const _32n = BigInt(32);
+const U32_MASK64 = /*#__PURE__*/ BigInt(2 ** 32 - 1);
+const _32n = /*#__PURE__*/ BigInt(32);
 
 // We are not using BigUint64Array, because they are extremely slow as per 2022
 export function fromBig(n: bigint, le = false) {

--- a/src/argon2.ts
+++ b/src/argon2.ts
@@ -1,7 +1,7 @@
 import * as assert from './_assert.js';
 import { Input, toBytes, u8, u32 } from './utils.js';
 import { blake2b } from './blake2b.js';
-import u64 from './_u64.js';
+import * as u64 from './_u64.js';
 
 // Experimental Argon2 RFC 9106 implementation. It may be removed at any time.
 enum Types {

--- a/src/argon2.ts
+++ b/src/argon2.ts
@@ -1,3 +1,4 @@
+import './_big-endian-check.js'
 import * as assert from './_assert.js';
 import { Input, toBytes, u8, u32 } from './utils.js';
 import { blake2b } from './blake2b.js';

--- a/src/argon2.ts
+++ b/src/argon2.ts
@@ -1,4 +1,4 @@
-import assert from './_assert.js';
+import * as assert from './_assert.js';
 import { Input, toBytes, u8, u32 } from './utils.js';
 import { blake2b } from './blake2b.js';
 import u64 from './_u64.js';

--- a/src/blake2b.ts
+++ b/src/blake2b.ts
@@ -4,12 +4,12 @@ import { toBytes, u32, wrapConstructorWithOpts } from './utils.js';
 
 // Same as SHA-512 but LE
 // prettier-ignore
-const IV = new Uint32Array([
+const IV = /*#__PURE__*/new Uint32Array([
   0xf3bcc908, 0x6a09e667, 0x84caa73b, 0xbb67ae85, 0xfe94f82b, 0x3c6ef372, 0x5f1d36f1, 0xa54ff53a,
   0xade682d1, 0x510e527f, 0x2b3e6c1f, 0x9b05688c, 0xfb41bd6b, 0x1f83d9ab, 0x137e2179, 0x5be0cd19
 ]);
 // Temporary buffer
-const BUF = new Uint32Array(32);
+const BUF = /*#__PURE__*/ new Uint32Array(32);
 
 // Mixing function G splitted in two halfs
 function G1(a: number, b: number, c: number, d: number, msg: Uint32Array, x: number) {
@@ -200,4 +200,6 @@ class BLAKE2b extends BLAKE2<BLAKE2b> {
  * @param msg - message that would be hashed
  * @param opts - dkLen, key, salt, personalization
  */
-export const blake2b = wrapConstructorWithOpts<BLAKE2b, BlakeOpts>((opts) => new BLAKE2b(opts));
+export const blake2b = /*#__PURE__*/ wrapConstructorWithOpts<BLAKE2b, BlakeOpts>(
+  (opts) => new BLAKE2b(opts)
+);

--- a/src/blake2b.ts
+++ b/src/blake2b.ts
@@ -1,5 +1,5 @@
 import { BLAKE2, BlakeOpts, SIGMA } from './_blake2.js';
-import u64 from './_u64.js';
+import * as u64 from './_u64.js';
 import { toBytes, u32, wrapConstructorWithOpts } from './utils.js';
 
 // Same as SHA-512 but LE

--- a/src/blake2b.ts
+++ b/src/blake2b.ts
@@ -1,3 +1,4 @@
+import './_big-endian-check.js'
 import { BLAKE2, BlakeOpts, SIGMA } from './_blake2.js';
 import * as u64 from './_u64.js';
 import { toBytes, u32, wrapConstructorWithOpts } from './utils.js';

--- a/src/blake2s.ts
+++ b/src/blake2s.ts
@@ -1,5 +1,5 @@
 import { BLAKE2, BlakeOpts, SIGMA } from './_blake2.js';
-import u64 from './_u64.js';
+import * as u64 from './_u64.js';
 import { rotr, toBytes, wrapConstructorWithOpts, u32 } from './utils.js';
 
 // Initial state:

--- a/src/blake2s.ts
+++ b/src/blake2s.ts
@@ -6,9 +6,7 @@ import { rotr, toBytes, wrapConstructorWithOpts, u32 } from './utils.js';
 // first 32 bits of the fractional parts of the square roots of the first 8 primes 2..19)
 // same as SHA-256
 // prettier-ignore
-export const IV = new Uint32Array([
-  0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19
-]);
+export const IV = /*#__PURE__*/new Uint32Array([0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19]);
 
 // Mixing function G splitted in two halfs
 function G1(a: number, b: number, c: number, d: number, x: number) {
@@ -133,4 +131,6 @@ class BLAKE2s extends BLAKE2<BLAKE2s> {
  * @param msg - message that would be hashed
  * @param opts - dkLen, key, salt, personalization
  */
-export const blake2s = wrapConstructorWithOpts<BLAKE2s, BlakeOpts>((opts) => new BLAKE2s(opts));
+export const blake2s = /*#__PURE__*/ wrapConstructorWithOpts<BLAKE2s, BlakeOpts>(
+  (opts) => new BLAKE2s(opts)
+);

--- a/src/blake2s.ts
+++ b/src/blake2s.ts
@@ -1,3 +1,4 @@
+import './_big-endian-check.js'
 import { BLAKE2, BlakeOpts, SIGMA } from './_blake2.js';
 import * as u64 from './_u64.js';
 import { rotr, toBytes, wrapConstructorWithOpts, u32 } from './utils.js';

--- a/src/blake3.ts
+++ b/src/blake3.ts
@@ -1,4 +1,4 @@
-import assert from './_assert.js';
+import * as assert from './_assert.js';
 import u64 from './_u64.js';
 import { BLAKE2 } from './_blake2.js';
 import { compress, IV } from './blake2s.js';

--- a/src/blake3.ts
+++ b/src/blake3.ts
@@ -1,5 +1,5 @@
 import * as assert from './_assert.js';
-import u64 from './_u64.js';
+import * as u64 from './_u64.js';
 import { BLAKE2 } from './_blake2.js';
 import { compress, IV } from './blake2s.js';
 import { Input, u8, u32, toBytes, HashXOF, wrapXOFConstructorWithOpts } from './utils.js';

--- a/src/blake3.ts
+++ b/src/blake3.ts
@@ -1,3 +1,4 @@
+import './_big-endian-check.js'
 import * as assert from './_assert.js';
 import * as u64 from './_u64.js';
 import { BLAKE2 } from './_blake2.js';

--- a/src/blake3.ts
+++ b/src/blake3.ts
@@ -15,12 +15,12 @@ enum Flags {
   DERIVE_KEY_MATERIAL = 1 << 6,
 }
 
-const SIGMA: Uint8Array = (() => {
-  const Id = Array.from({ length: 16 }, (_, i) => i);
+const SIGMA: Uint8Array = /*#__PURE__*/ (() => {
+  const Id = /*#__PURE__*/ Array.from({ length: 16 }, (_, i) => i);
   const permute = (arr: number[]) =>
     [2, 6, 3, 10, 7, 0, 4, 13, 1, 11, 12, 5, 9, 14, 15, 8].map((i) => arr[i]);
   const res: number[] = [];
-  for (let i = 0, v = Id; i < 7; i++, v = permute(v)) res.push(...v);
+  for (let i = 0, v = Id; i < 7; i++, v = /*#__PURE__*/ permute(v)) res.push(...v);
   return Uint8Array.from(res);
 })();
 
@@ -243,4 +243,6 @@ class BLAKE3 extends BLAKE2<BLAKE3> implements HashXOF<BLAKE3> {
  * @param msg - message that would be hashed
  * @param opts - dkLen, key, context
  */
-export const blake3 = wrapXOFConstructorWithOpts<BLAKE3, Blake3Opts>((opts) => new BLAKE3(opts));
+export const blake3 = /*#__PURE__*/ wrapXOFConstructorWithOpts<BLAKE3, Blake3Opts>(
+  (opts) => new BLAKE3(opts)
+);

--- a/src/eskdf.ts
+++ b/src/eskdf.ts
@@ -1,3 +1,4 @@
+import './_big-endian-check.js'
 import { bytes as assertBytes } from './_assert.js';
 import { hkdf } from './hkdf.js';
 import { sha256 } from './sha256.js';

--- a/src/hkdf.ts
+++ b/src/hkdf.ts
@@ -1,4 +1,4 @@
-import assert from './_assert.js';
+import * as assert from './_assert.js';
 import { CHash, Input, toBytes } from './utils.js';
 import { hmac } from './hmac.js';
 

--- a/src/hkdf.ts
+++ b/src/hkdf.ts
@@ -1,3 +1,4 @@
+import './_big-endian-check.js'
 import * as assert from './_assert.js';
 import { CHash, Input, toBytes } from './utils.js';
 import { hmac } from './hmac.js';

--- a/src/hkdf.ts
+++ b/src/hkdf.ts
@@ -23,8 +23,8 @@ export function extract(hash: CHash, ikm: Input, salt?: Input) {
 }
 
 // HKDF-Expand(PRK, info, L) -> OKM
-const HKDF_COUNTER = new Uint8Array([0]);
-const EMPTY_BUFFER = new Uint8Array();
+const HKDF_COUNTER = /*#__PURE__*/ new Uint8Array([0]);
+const EMPTY_BUFFER = /*#__PURE__*/ new Uint8Array();
 
 /**
  * HKDF-expand from the spec.

--- a/src/hmac.ts
+++ b/src/hmac.ts
@@ -1,4 +1,4 @@
-import assert from './_assert.js';
+import * as assert from './_assert.js';
 import { Hash, CHash, Input, toBytes } from './utils.js';
 // HMAC (RFC 2104)
 export class HMAC<T extends Hash<T>> extends Hash<HMAC<T>> {

--- a/src/hmac.ts
+++ b/src/hmac.ts
@@ -1,3 +1,4 @@
+import './_big-endian-check.js'
 import * as assert from './_assert.js';
 import { Hash, CHash, Input, toBytes } from './utils.js';
 // HMAC (RFC 2104)

--- a/src/pbkdf2.ts
+++ b/src/pbkdf2.ts
@@ -1,3 +1,4 @@
+import './_big-endian-check.js'
 import * as assert from './_assert.js';
 import { hmac } from './hmac.js';
 import { Hash, CHash, Input, createView, toBytes, checkOpts, asyncLoop } from './utils.js';

--- a/src/pbkdf2.ts
+++ b/src/pbkdf2.ts
@@ -1,4 +1,4 @@
-import assert from './_assert.js';
+import * as assert from './_assert.js';
 import { hmac } from './hmac.js';
 import { Hash, CHash, Input, createView, toBytes, checkOpts, asyncLoop } from './utils.js';
 

--- a/src/ripemd160.ts
+++ b/src/ripemd160.ts
@@ -3,26 +3,28 @@ import { wrapConstructor } from './utils.js';
 
 // https://homes.esat.kuleuven.be/~bosselae/ripemd160.html
 // https://homes.esat.kuleuven.be/~bosselae/ripemd160/pdf/AB-9601/AB-9601.pdf
-const Rho = new Uint8Array([7, 4, 13, 1, 10, 6, 15, 3, 12, 0, 9, 5, 2, 14, 11, 8]);
-const Id = Uint8Array.from({ length: 16 }, (_, i) => i);
-const Pi = Id.map((i) => (9 * i + 5) % 16);
+const Rho = /*#__PURE__*/ new Uint8Array([7, 4, 13, 1, 10, 6, 15, 3, 12, 0, 9, 5, 2, 14, 11, 8]);
+const Id = /*#__PURE__*/ Uint8Array.from({ length: 16 }, (_, i) => i);
+const Pi = /*#__PURE__*/ Id.map((i) => (9 * i + 5) % 16);
 let idxL = [Id];
 let idxR = [Pi];
 for (let i = 0; i < 4; i++) for (let j of [idxL, idxR]) j.push(j[i].map((k) => Rho[k]));
 
-const shifts = [
+const shifts = /*#__PURE__*/ [
   [11, 14, 15, 12, 5, 8, 7, 9, 11, 13, 14, 15, 6, 7, 9, 8],
   [12, 13, 11, 15, 6, 9, 9, 7, 12, 15, 11, 13, 7, 8, 7, 7],
   [13, 15, 14, 11, 7, 7, 6, 8, 13, 14, 13, 12, 5, 5, 6, 9],
   [14, 11, 12, 14, 8, 6, 5, 5, 15, 12, 15, 14, 9, 9, 8, 6],
   [15, 12, 13, 13, 9, 5, 8, 6, 14, 11, 12, 11, 8, 6, 5, 5],
 ].map((i) => new Uint8Array(i));
-
-const shiftsL = idxL.map((idx, i) => idx.map((j) => shifts[i][j]));
-const shiftsR = idxR.map((idx, i) => idx.map((j) => shifts[i][j]));
-
-const Kl = new Uint32Array([0x00000000, 0x5a827999, 0x6ed9eba1, 0x8f1bbcdc, 0xa953fd4e]);
-const Kr = new Uint32Array([0x50a28be6, 0x5c4dd124, 0x6d703ef3, 0x7a6d76e9, 0x00000000]);
+const shiftsL = /*#__PURE__*/ idxL.map((idx, i) => idx.map((j) => shifts[i][j]));
+const shiftsR = /*#__PURE__*/ idxR.map((idx, i) => idx.map((j) => shifts[i][j]));
+const Kl = /*#__PURE__*/ new Uint32Array([
+  0x00000000, 0x5a827999, 0x6ed9eba1, 0x8f1bbcdc, 0xa953fd4e,
+]);
+const Kr = /*#__PURE__*/ new Uint32Array([
+  0x50a28be6, 0x5c4dd124, 0x6d703ef3, 0x7a6d76e9, 0x00000000,
+]);
 // The rotate left (circular left shift) operation for uint32
 const rotl = (word: number, shift: number) => (word << shift) | (word >>> (32 - shift));
 // It's called f() in spec.
@@ -34,7 +36,7 @@ function f(group: number, x: number, y: number, z: number): number {
   else return x ^ (y | ~z);
 }
 // Temporary buffer, not used to store anything between runs
-const BUF = new Uint32Array(16);
+const BUF = /*#__PURE__*/ new Uint32Array(16);
 export class RIPEMD160 extends SHA2<RIPEMD160> {
   private h0 = 0x67452301 | 0;
   private h1 = 0xefcdab89 | 0;
@@ -105,4 +107,4 @@ export class RIPEMD160 extends SHA2<RIPEMD160> {
  * RIPEMD-160 - a hash function from 1990s.
  * @param message - msg that would be hashed
  */
-export const ripemd160 = wrapConstructor(() => new RIPEMD160());
+export const ripemd160 = /*#__PURE__*/ wrapConstructor(() => new RIPEMD160());

--- a/src/ripemd160.ts
+++ b/src/ripemd160.ts
@@ -1,3 +1,4 @@
+import './_big-endian-check.js'
 import { SHA2 } from './_sha2.js';
 import { wrapConstructor } from './utils.js';
 

--- a/src/scrypt.ts
+++ b/src/scrypt.ts
@@ -1,3 +1,4 @@
+import './_big-endian-check.js'
 import * as assert from './_assert.js';
 import { sha256 } from './sha256.js';
 import { pbkdf2 } from './pbkdf2.js';

--- a/src/scrypt.ts
+++ b/src/scrypt.ts
@@ -1,4 +1,4 @@
-import assert from './_assert.js';
+import * as assert from './_assert.js';
 import { sha256 } from './sha256.js';
 import { pbkdf2 } from './pbkdf2.js';
 import { asyncLoop, checkOpts, Input, u32 } from './utils.js';

--- a/src/sha1.ts
+++ b/src/sha1.ts
@@ -12,11 +12,13 @@ const Chi = (a: number, b: number, c: number) => (a & b) ^ (~a & c);
 const Maj = (a: number, b: number, c: number) => (a & b) ^ (a & c) ^ (b & c);
 
 // Initial state
-const IV = new Uint32Array([0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476, 0xc3d2e1f0]);
+const IV = /*#__PURE__*/ new Uint32Array([
+  0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476, 0xc3d2e1f0,
+]);
 
 // Temporary buffer, not used to store anything between runs
 // Named this way because it matches specification.
-const SHA1_W = new Uint32Array(80);
+const SHA1_W = /*#__PURE__*/ new Uint32Array(80);
 class SHA1 extends SHA2<SHA1> {
   private A = IV[0] | 0;
   private B = IV[1] | 0;
@@ -83,4 +85,4 @@ class SHA1 extends SHA2<SHA1> {
   }
 }
 
-export const sha1 = wrapConstructor(() => new SHA1());
+export const sha1 = /*#__PURE__*/ wrapConstructor(() => new SHA1());

--- a/src/sha1.ts
+++ b/src/sha1.ts
@@ -1,3 +1,4 @@
+import './_big-endian-check.js'
 import { SHA2 } from './_sha2.js';
 import { wrapConstructor } from './utils.js';
 

--- a/src/sha256.ts
+++ b/src/sha256.ts
@@ -9,7 +9,7 @@ const Maj = (a: number, b: number, c: number) => (a & b) ^ (a & c) ^ (b & c);
 // Round constants:
 // first 32 bits of the fractional parts of the cube roots of the first 64 primes 2..311)
 // prettier-ignore
-const SHA256_K = new Uint32Array([
+const SHA256_K = /*#__PURE__*/new Uint32Array([
   0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
   0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
   0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
@@ -22,13 +22,13 @@ const SHA256_K = new Uint32Array([
 
 // Initial state (first 32 bits of the fractional parts of the square roots of the first 8 primes 2..19):
 // prettier-ignore
-const IV = new Uint32Array([
+const IV = /*#__PURE__*/new Uint32Array([
   0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19
 ]);
 
 // Temporary buffer, not used to store anything between runs
 // Named this way because it matches specification.
-const SHA256_W = new Uint32Array(64);
+const SHA256_W = /*#__PURE__*/ new Uint32Array(64);
 class SHA256 extends SHA2<SHA256> {
   // We cannot use array here since array allows indexing by variable
   // which means optimizer/compiler cannot use registers.
@@ -126,5 +126,5 @@ class SHA224 extends SHA256 {
  * SHA2-256 hash function
  * @param message - data that would be hashed
  */
-export const sha256 = wrapConstructor(() => new SHA256());
-export const sha224 = wrapConstructor(() => new SHA224());
+export const sha256 = /*#__PURE__*/ wrapConstructor(() => new SHA256());
+export const sha224 = /*#__PURE__*/ wrapConstructor(() => new SHA224());

--- a/src/sha256.ts
+++ b/src/sha256.ts
@@ -1,3 +1,4 @@
+import './_big-endian-check.js'
 import { SHA2 } from './_sha2.js';
 import { rotr, wrapConstructor } from './utils.js';
 

--- a/src/sha3-addons.ts
+++ b/src/sha3-addons.ts
@@ -1,3 +1,4 @@
+import './_big-endian-check.js'
 import { number as assertNumber } from './_assert.js';
 import { Input, toBytes, wrapConstructorWithOpts, u32, Hash, HashXOF } from './utils.js';
 import { Keccak, ShakeOpts } from './sha3.js';

--- a/src/sha3.ts
+++ b/src/sha3.ts
@@ -12,12 +12,12 @@ import {
 
 // Various per round constants calculations
 const [SHA3_PI, SHA3_ROTL, _SHA3_IOTA]: [number[], number[], bigint[]] = [[], [], []];
-const _0n = BigInt(0);
-const _1n = BigInt(1);
-const _2n = BigInt(2);
-const _7n = BigInt(7);
-const _256n = BigInt(256);
-const _0x71n = BigInt(0x71);
+const _0n = /*#__PURE__*/ BigInt(0);
+const _1n = /*#__PURE__*/ BigInt(1);
+const _2n = /*#__PURE__*/ BigInt(2);
+const _7n = /*#__PURE__*/ BigInt(7);
+const _256n = /*#__PURE__*/ BigInt(256);
+const _0x71n = /*#__PURE__*/ BigInt(0x71);
 for (let round = 0, R = _1n, x = 1, y = 0; round < 24; round++) {
   // Pi
   [x, y] = [y, (2 * x + 3 * y) % 5];
@@ -28,11 +28,11 @@ for (let round = 0, R = _1n, x = 1, y = 0; round < 24; round++) {
   let t = _0n;
   for (let j = 0; j < 7; j++) {
     R = ((R << _1n) ^ ((R >> _7n) * _0x71n)) % _256n;
-    if (R & _2n) t ^= _1n << ((_1n << BigInt(j)) - _1n);
+    if (R & _2n) t ^= _1n << ((_1n << /*#__PURE__*/ BigInt(j)) - _1n);
   }
   _SHA3_IOTA.push(t);
 }
-const [SHA3_IOTA_H, SHA3_IOTA_L] = u64.split(_SHA3_IOTA, true);
+const [SHA3_IOTA_H, SHA3_IOTA_L] = /*#__PURE__*/ u64.split(_SHA3_IOTA, true);
 
 // Left rotation (without 0, 32, 64)
 const rotlH = (h: number, l: number, s: number) =>
@@ -193,22 +193,22 @@ export class Keccak extends Hash<Keccak> implements HashXOF<Keccak> {
 const gen = (suffix: number, blockLen: number, outputLen: number) =>
   wrapConstructor(() => new Keccak(blockLen, suffix, outputLen));
 
-export const sha3_224 = gen(0x06, 144, 224 / 8);
+export const sha3_224 = /*#__PURE__*/ gen(0x06, 144, 224 / 8);
 /**
  * SHA3-256 hash function
  * @param message - that would be hashed
  */
-export const sha3_256 = gen(0x06, 136, 256 / 8);
-export const sha3_384 = gen(0x06, 104, 384 / 8);
-export const sha3_512 = gen(0x06, 72, 512 / 8);
-export const keccak_224 = gen(0x01, 144, 224 / 8);
+export const sha3_256 = /*#__PURE__*/ gen(0x06, 136, 256 / 8);
+export const sha3_384 = /*#__PURE__*/ gen(0x06, 104, 384 / 8);
+export const sha3_512 = /*#__PURE__*/ gen(0x06, 72, 512 / 8);
+export const keccak_224 = /*#__PURE__*/ gen(0x01, 144, 224 / 8);
 /**
  * keccak-256 hash function. Different from SHA3-256.
  * @param message - that would be hashed
  */
-export const keccak_256 = gen(0x01, 136, 256 / 8);
-export const keccak_384 = gen(0x01, 104, 384 / 8);
-export const keccak_512 = gen(0x01, 72, 512 / 8);
+export const keccak_256 = /*#__PURE__*/ gen(0x01, 136, 256 / 8);
+export const keccak_384 = /*#__PURE__*/ gen(0x01, 104, 384 / 8);
+export const keccak_512 = /*#__PURE__*/ gen(0x01, 72, 512 / 8);
 
 export type ShakeOpts = { dkLen?: number };
 
@@ -218,5 +218,5 @@ const genShake = (suffix: number, blockLen: number, outputLen: number) =>
       new Keccak(blockLen, suffix, opts.dkLen === undefined ? outputLen : opts.dkLen, true)
   );
 
-export const shake128 = genShake(0x1f, 168, 128 / 8);
-export const shake256 = genShake(0x1f, 136, 256 / 8);
+export const shake128 = /*#__PURE__*/ genShake(0x1f, 168, 128 / 8);
+export const shake256 = /*#__PURE__*/ genShake(0x1f, 136, 256 / 8);

--- a/src/sha3.ts
+++ b/src/sha3.ts
@@ -1,3 +1,4 @@
+import './_big-endian-check.js'
 import * as assert from './_assert.js';
 import * as u64 from './_u64.js';
 import {

--- a/src/sha3.ts
+++ b/src/sha3.ts
@@ -1,4 +1,4 @@
-import assert from './_assert.js';
+import * as assert from './_assert.js';
 import u64 from './_u64.js';
 import {
   Hash,

--- a/src/sha3.ts
+++ b/src/sha3.ts
@@ -1,5 +1,5 @@
 import * as assert from './_assert.js';
-import u64 from './_u64.js';
+import * as u64 from './_u64.js';
 import {
   Hash,
   u32,

--- a/src/sha512.ts
+++ b/src/sha512.ts
@@ -1,5 +1,5 @@
 import { SHA2 } from './_sha2.js';
-import u64 from './_u64.js';
+import * as u64 from './_u64.js';
 import { wrapConstructor } from './utils.js';
 
 // Round contants (first 32 bits of the fractional parts of the cube roots of the first 80 primes 2..409):

--- a/src/sha512.ts
+++ b/src/sha512.ts
@@ -4,7 +4,7 @@ import { wrapConstructor } from './utils.js';
 
 // Round contants (first 32 bits of the fractional parts of the cube roots of the first 80 primes 2..409):
 // prettier-ignore
-const [SHA512_Kh, SHA512_Kl] = u64.split([
+const [SHA512_Kh, SHA512_Kl] = /*#__PURE__*/u64.split( /*#__PURE__*/[
   '0x428a2f98d728ae22', '0x7137449123ef65cd', '0xb5c0fbcfec4d3b2f', '0xe9b5dba58189dbbc',
   '0x3956c25bf348b538', '0x59f111f1b605d019', '0x923f82a4af194f9b', '0xab1c5ed5da6d8118',
   '0xd807aa98a3030242', '0x12835b0145706fbe', '0x243185be4ee4b28c', '0x550c7dc3d5ffb4e2',
@@ -28,9 +28,8 @@ const [SHA512_Kh, SHA512_Kl] = u64.split([
 ].map(n => BigInt(n)));
 
 // Temporary buffer, not used to store anything between runs
-const SHA512_W_H = new Uint32Array(80);
-const SHA512_W_L = new Uint32Array(80);
-
+const SHA512_W_H = /*#__PURE__*/ new Uint32Array(80);
+const SHA512_W_L = /*#__PURE__*/ new Uint32Array(80);
 export class SHA512 extends SHA2<SHA512> {
   // We cannot use array here since array allows indexing by variable which means optimizer/compiler cannot use registers.
   // Also looks cleaner and easier to verify with spec.
@@ -241,7 +240,7 @@ class SHA384 extends SHA512 {
   }
 }
 
-export const sha512 = wrapConstructor(() => new SHA512());
-export const sha512_224 = wrapConstructor(() => new SHA512_224());
-export const sha512_256 = wrapConstructor(() => new SHA512_256());
-export const sha384 = wrapConstructor(() => new SHA384());
+export const sha512 = /*#__PURE__*/ wrapConstructor(() => new SHA512());
+export const sha512_224 = /*#__PURE__*/ wrapConstructor(() => new SHA512_224());
+export const sha512_256 = /*#__PURE__*/ wrapConstructor(() => new SHA512_256());
+export const sha384 = /*#__PURE__*/ wrapConstructor(() => new SHA384());

--- a/src/sha512.ts
+++ b/src/sha512.ts
@@ -1,3 +1,4 @@
+import './_big-endian-check.js'
 import { SHA2 } from './_sha2.js';
 import * as u64 from './_u64.js';
 import { wrapConstructor } from './utils.js';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,11 +25,8 @@ export const createView = (arr: TypedArray) =>
 // The rotate right (circular right shift) operation for uint32
 export const rotr = (word: number, shift: number) => (word << (32 - shift)) | (word >>> shift);
 
-// big-endian hardware is rare. Just in case someone still decides to run hashes:
-// early-throw an error because we don't support BE yet.
 export const isLE =
   /*#__PURE__*/ new Uint8Array(/*#__PURE__*/ new Uint32Array([0x11223344]).buffer)[0] === 0x44;
-if (!isLE) throw new Error('Non little-endian hardware is not supported');
 
 const hexes = /*#__PURE__*/ Array.from({ length: 256 }, (v, i) => i.toString(16).padStart(2, '0'));
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,10 +27,11 @@ export const rotr = (word: number, shift: number) => (word << (32 - shift)) | (w
 
 // big-endian hardware is rare. Just in case someone still decides to run hashes:
 // early-throw an error because we don't support BE yet.
-export const isLE = new Uint8Array(new Uint32Array([0x11223344]).buffer)[0] === 0x44;
+export const isLE =
+  /*#__PURE__*/ new Uint8Array(/*#__PURE__*/ new Uint32Array([0x11223344]).buffer)[0] === 0x44;
 if (!isLE) throw new Error('Non little-endian hardware is not supported');
 
-const hexes = Array.from({ length: 256 }, (v, i) => i.toString(16).padStart(2, '0'));
+const hexes = /*#__PURE__*/ Array.from({ length: 256 }, (v, i) => i.toString(16).padStart(2, '0'));
 /**
  * @example bytesToHex(Uint8Array.from([0xca, 0xfe, 0x01, 0x23])) // 'cafe0123'
  */

--- a/test/u64.test.js
+++ b/test/u64.test.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const { should } = require('micro-should');
-const u64 = require('../_u64').default;
+const u64 = require('../_u64');
 
 const U64_MASK = 2n ** 64n - 1n;
 const U32_MASK = (2 ** 32 - 1) | 0;


### PR DESCRIPTION
I applied some optimizations to reduce bundle size:

- `sideEffects: false` to improve dead code elimination 
- removed default export in `_u64`
- migrated `_assert` and `_u64` module to wildcard imports to enable tree-shaking
- added `/*#__PURE__*/` annotation to all top-level invocations

### sizes (with all dependencies, minified and gzipped):

```
blake2b from blake2b
Size:         3 kB      →   2.71 kB

blake2s from blake2s
Size:         2.75 kB   →   2.31 kB

blake3 from blake3
Size:         4.22 kB   →   3.19 kB

hmac from hmac
Size:         1.03 kB   →   891 B

hkdf from hkdf
Size:         1.25 kB   →   1.11 kB

pbkdf2 from pbkdf2
Size:         1.47 kB   →   1.33 kB

pbkdf2Async from pbkdf2
Size:         1.54 kB   →   1.41 kB

ripemd160 from ripemd160
Size:         2.15 kB   →   1.98 kB

scrypt from scrypt
Size:         4.32 kB   →   4.13 kB

scryptAsync from scrypt
Size:         4.39 kB   →   4.2 kB

sha256 from sha256
Size:         2.45 kB   →   2.18 kB

sha512 from sha512
Size:         4.09 kB   →   3.44 kB

sha1 from sha1
Size:         1.82 kB   →   1.65 kB

sha3_224 from sha3
Size:         2.06 kB   →   1.79 kB

sha3_256 from sha3
Size:         2.06 kB   →   1.79 kB

sha3_384 from sha3
Size:         2.06 kB   →   1.79 kB

sha3_512 from sha3
Size:         2.06 kB   →   1.79 kB

keccakP from sha3
Size:         2.06 kB   →   705 B

keccak_256 from sha3
Size:         2.06 kB   →   1.79 kB

keccak_384 from sha3
Size:         2.06 kB   →   1.79 kB

keccak_512 from sha3
Size:         2.06 kB   →   1.79 kB

cshake128 from sha3-addons
Size:         2.32 kB   →   2.04 kB

cshake256 from sha3-addons
Size:         2.32 kB   →   2.04 kB

kmac128 from sha3-addons
Size:         2.5 kB    →   2.2 kB

kmac256 from sha3-addons
Size:         2.5 kB    →   2.19 kB

k12 from sha3-addons
Size:         2.51 kB   →   2.24 kB

m14 from sha3-addons
Size:         2.51 kB   →   2.24 kB

argon2id from argon2
Size:         4.9 kB    →   4.6 kB

eskdf from eskdf
Size:         5.43 kB   →    5.28 kB
```

i used #62 to test changes