### PR TITLE
use const enums

### DIFF
--- a/src/argon2.ts
+++ b/src/argon2.ts
@@ -4,7 +4,7 @@ import { blake2b } from './blake2b.js';
 import u64 from './_u64.js';
 
 // Experimental Argon2 RFC 9106 implementation. It may be removed at any time.
-enum Types {
+const enum Types {
   Argond2d = 0,
   Argon2i = 1,
   Argon2id = 2,

--- a/src/blake3.ts
+++ b/src/blake3.ts
@@ -5,7 +5,7 @@ import { compress, IV } from './blake2s.js';
 import { Input, u8, u32, toBytes, HashXOF, wrapXOFConstructorWithOpts } from './utils.js';
 
 // Flag bitset
-enum Flags {
+const enum Flags {
   CHUNK_START = 1 << 0,
   CHUNK_END = 1 << 1,
   PARENT = 1 << 2,


### PR DESCRIPTION
const enums don't have any runtime


```ts
// Flag bitset
enum Flags {
  CHUNK_START = 1 << 0,
  CHUNK_END = 1 << 1,
  PARENT = 1 << 2,
  ROOT = 1 << 3,
  KEYED_HASH = 1 << 4,
  DERIVE_KEY_CONTEXT = 1 << 5,
  DERIVE_KEY_MATERIAL = 1 << 6,
}

export const example = [Flags.CHUNK_START, Flags.CHUNK_END]
````

compiled into: 

```js
// Flag bitset
var Flags;
(function (Flags) {
    Flags[Flags["CHUNK_START"] = 1] = "CHUNK_START";
    Flags[Flags["CHUNK_END"] = 2] = "CHUNK_END";
    Flags[Flags["PARENT"] = 4] = "PARENT";
    Flags[Flags["ROOT"] = 8] = "ROOT";
    Flags[Flags["KEYED_HASH"] = 16] = "KEYED_HASH";
    Flags[Flags["DERIVE_KEY_CONTEXT"] = 32] = "DERIVE_KEY_CONTEXT";
    Flags[Flags["DERIVE_KEY_MATERIAL"] = 64] = "DERIVE_KEY_MATERIAL";
})(Flags || (Flags = {}));
export const example = [Flags.CHUNK_START, Flags.CHUNK_END];
```

to support extending in runtime, when const enums just compiled to single values:

```js
export const example = [1 /* Flags.CHUNK_START */, 2 /* Flags.CHUNK_END */];
```

this PR should decrease bundle size for entries that use `enums`