### PR TITLE
docs: update ripemd160 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ const rand1b = p.fetch(1);
 import { ripemd160 } from '@noble/hashes/ripemd160';
 // function ripemd160(data: Uint8Array): Uint8Array;
 const hash8 = ripemd160('abc');
-const hash9 = ripemd160()
+const hash9 = ripemd160
   .create()
   .update(Uint8Array.from([1, 2, 3]))
   .digest();


### PR DESCRIPTION
The ripemd160 example was not referencing `ripemd160.create` as a static method.

@sublimator found the issue when I copied your examples over to the readme for an isomorphic implementation of various hashes. https://github.com/XRPLF/xrpl.js/pull/2273/files#r1317170863