### PR TITLE
Add support for big endian platforms

### DIFF
--- a/src/_blake.ts
+++ b/src/_blake.ts
@@ -1,5 +1,5 @@
 import { number, exists, output } from './_assert.js';
-import { Hash, Input, toBytes, u32, isLE, byteSwap, byteSwap32 } from './utils.js';
+import { Hash, Input, toBytes, u32, isLE, byteSwap32, byteSwapIfBE } from './utils.js';
 
 // Blake is based on ChaCha permutation.
 
@@ -110,7 +110,7 @@ export abstract class BLAKE<T extends BLAKE<T>> extends Hash<T> {
     this.compress(buffer32, 0, true);
     if (!isLE) byteSwap32(buffer32);
     const out32 = u32(out);
-    this.get().forEach(isLE ? (v, i) => (out32[i] = v) : (v, i) => (out32[i] = byteSwap(v)));
+    this.get().forEach((v, i) => (out32[i] = byteSwapIfBE(v)));
   }
   digest() {
     const { buffer, outputLen } = this;

--- a/src/blake2b.ts
+++ b/src/blake2b.ts
@@ -1,6 +1,6 @@
 import { BLAKE, BlakeOpts, SIGMA } from './_blake.js';
 import u64 from './_u64.js';
-import { toBytes, u32, wrapConstructorWithOpts } from './utils.js';
+import { toBytes, u32, wrapConstructorWithOpts, byteSwapIfBE } from './utils.js';
 
 // Same as SHA-512 but LE
 // prettier-ignore
@@ -87,17 +87,17 @@ class BLAKE2b extends BLAKE<BLAKE2b> {
     this.v0l ^= this.outputLen | (keyLength << 8) | (0x01 << 16) | (0x01 << 24);
     if (opts.salt) {
       const salt = u32(toBytes(opts.salt));
-      this.v4l ^= salt[0];
-      this.v4h ^= salt[1];
-      this.v5l ^= salt[2];
-      this.v5h ^= salt[3];
+      this.v4l ^= byteSwapIfBE(salt[0]);
+      this.v4h ^= byteSwapIfBE(salt[1]);
+      this.v5l ^= byteSwapIfBE(salt[2]);
+      this.v5h ^= byteSwapIfBE(salt[3]);
     }
     if (opts.personalization) {
       const pers = u32(toBytes(opts.personalization));
-      this.v6l ^= pers[0];
-      this.v6h ^= pers[1];
-      this.v7l ^= pers[2];
-      this.v7h ^= pers[3];
+      this.v6l ^= byteSwapIfBE(pers[0]);
+      this.v6h ^= byteSwapIfBE(pers[1]);
+      this.v7l ^= byteSwapIfBE(pers[2]);
+      this.v7h ^= byteSwapIfBE(pers[3]);
     }
     if (opts.key) {
       // Pad to blockLen and update

--- a/src/blake2s.ts
+++ b/src/blake2s.ts
@@ -1,6 +1,6 @@
 import { BLAKE, BlakeOpts, SIGMA } from './_blake.js';
 import { fromBig } from './_u64.js';
-import { rotr, toBytes, wrapConstructorWithOpts, u32 } from './utils.js';
+import { rotr, toBytes, wrapConstructorWithOpts, u32, byteSwapIfBE } from './utils.js';
 
 // Initial state: same as SHA256
 // first 32 bits of the fractional parts of the square roots of the first 8 primes 2..19
@@ -71,13 +71,13 @@ class BLAKE2s extends BLAKE<BLAKE2s> {
     this.v0 ^= this.outputLen | (keyLength << 8) | (0x01 << 16) | (0x01 << 24);
     if (opts.salt) {
       const salt = u32(toBytes(opts.salt));
-      this.v4 ^= salt[0];
-      this.v5 ^= salt[1];
+      this.v4 ^= byteSwapIfBE(salt[0]);
+      this.v5 ^= byteSwapIfBE(salt[1]);
     }
     if (opts.personalization) {
       const pers = u32(toBytes(opts.personalization));
-      this.v6 ^= pers[0];
-      this.v7 ^= pers[1];
+      this.v6 ^= byteSwapIfBE(pers[0]);
+      this.v7 ^= byteSwapIfBE(pers[1]);
     }
     if (opts.key) {
       // Pad to blockLen and update

--- a/src/blake3.ts
+++ b/src/blake3.ts
@@ -2,7 +2,16 @@ import { bytes, exists, number, output } from './_assert.js';
 import { fromBig } from './_u64.js';
 import { BLAKE } from './_blake.js';
 import { compress, B2S_IV } from './blake2s.js';
-import { Input, u8, u32, toBytes, HashXOF, wrapXOFConstructorWithOpts, isLE, byteSwap32 } from './utils.js';
+import {
+  Input,
+  u8,
+  u32,
+  toBytes,
+  HashXOF,
+  wrapXOFConstructorWithOpts,
+  isLE,
+  byteSwap32,
+} from './utils.js';
 
 // Blake3 is single-option Blake2 with reduced security (round count).
 

--- a/src/scrypt.ts
+++ b/src/scrypt.ts
@@ -1,7 +1,7 @@
 import { number as assertNumber } from './_assert.js';
 import { sha256 } from './sha256.js';
 import { pbkdf2 } from './pbkdf2.js';
-import { rotl, asyncLoop, checkOpts, Input, u32 } from './utils.js';
+import { rotl, asyncLoop, checkOpts, Input, u32, isLE, byteSwap32 } from './utils.js';
 
 // RFC 7914 Scrypt KDF
 
@@ -186,6 +186,7 @@ export function scrypt(password: Input, salt: Input, opts: ScryptOpts) {
     salt,
     opts
   );
+  if (!isLE) byteSwap32(B32);
   for (let pi = 0; pi < p; pi++) {
     const Pi = blockSize32 * pi;
     for (let i = 0; i < blockSize32; i++) V[i] = B32[Pi + i]; // V[0] = B[i]
@@ -203,6 +204,7 @@ export function scrypt(password: Input, salt: Input, opts: ScryptOpts) {
       blockMixCb();
     }
   }
+  if (!isLE) byteSwap32(B32);
   return scryptOutput(password, dkLen, B, V, tmp);
 }
 
@@ -215,6 +217,7 @@ export async function scryptAsync(password: Input, salt: Input, opts: ScryptOpts
     salt,
     opts
   );
+  if (!isLE) byteSwap32(B32);
   for (let pi = 0; pi < p; pi++) {
     const Pi = blockSize32 * pi;
     for (let i = 0; i < blockSize32; i++) V[i] = B32[Pi + i]; // V[0] = B[i]
@@ -233,5 +236,6 @@ export async function scryptAsync(password: Input, salt: Input, opts: ScryptOpts
       blockMixCb();
     });
   }
+  if (!isLE) byteSwap32(B32);
   return scryptOutput(password, dkLen, B, V, tmp);
 }

--- a/src/sha3.ts
+++ b/src/sha3.ts
@@ -8,6 +8,8 @@ import {
   wrapConstructor,
   wrapXOFConstructorWithOpts,
   HashXOF,
+  isLE,
+  byteSwap32,
 } from './utils.js';
 
 // SHA3 (keccak) is based on a new design: basically, the internal state is bigger than output size.
@@ -112,7 +114,9 @@ export class Keccak extends Hash<Keccak> implements HashXOF<Keccak> {
     this.state32 = u32(this.state);
   }
   protected keccak() {
+    if (!isLE) byteSwap32(this.state32);
     keccakP(this.state32, this.rounds);
+    if (!isLE) byteSwap32(this.state32);
     this.posOut = 0;
     this.pos = 0;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,12 +34,7 @@ export const rotr = (word: number, shift: number) => (word << (32 - shift)) | (w
 export const rotl = (word: number, shift: number) =>
   (word << shift) | ((word >>> (32 - shift)) >>> 0);
 
-// big-endian hardware is rare. Just in case someone still decides to run hashes:
-// early-throw an error because we don't support BE yet.
-// Other libraries would silently corrupt the data instead of throwing an error,
-// when they don't support it.
 export const isLE = new Uint8Array(new Uint32Array([0x11223344]).buffer)[0] === 0x44;
-if (!isLE) throw new Error('Non little-endian hardware is not supported');
 
 // Array where index 0xf0 (240) is mapped to string 'f0'
 const hexes = /* @__PURE__ */ Array.from({ length: 256 }, (_, i) =>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,6 +35,18 @@ export const rotl = (word: number, shift: number) =>
   (word << shift) | ((word >>> (32 - shift)) >>> 0);
 
 export const isLE = new Uint8Array(new Uint32Array([0x11223344]).buffer)[0] === 0x44;
+// The byte swap operation for uint32
+export const byteSwap = (word: number) =>
+  ((word << 24) & 0xff000000) | ((word << 8) & 0xff0000) | ((word >>> 8) & 0xff00) | ((word >>> 24) & 0xff);
+// Conditionally byte swap if on a big-endian platform
+export const byteSwapIfBE = isLE ? (n: number) => n : (n: number) => byteSwap(n);
+
+// In place byte swap for Uint32Array
+export function byteSwap32(arr: Uint32Array) {
+  for (let i = 0; i < arr.length; i++) {
+    arr[i] = byteSwap(arr[i]);
+  }
+}
 
 // Array where index 0xf0 (240) is mapped to string 'f0'
 const hexes = /* @__PURE__ */ Array.from({ length: 256 }, (_, i) =>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,7 +37,10 @@ export const rotl = (word: number, shift: number) =>
 export const isLE = new Uint8Array(new Uint32Array([0x11223344]).buffer)[0] === 0x44;
 // The byte swap operation for uint32
 export const byteSwap = (word: number) =>
-  ((word << 24) & 0xff000000) | ((word << 8) & 0xff0000) | ((word >>> 8) & 0xff00) | ((word >>> 24) & 0xff);
+  ((word << 24) & 0xff000000) |
+  ((word << 8) & 0xff0000) |
+  ((word >>> 8) & 0xff00) |
+  ((word >>> 24) & 0xff);
 // Conditionally byte swap if on a big-endian platform
 export const byteSwapIfBE = isLE ? (n: number) => n : (n: number) => byteSwap(n);
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const { should } = require('micro-should');
 const { optional, integer, gen } = require('./generator');
+const { byteSwap, byteSwapIfBE, byteSwap32, isLE } = require('../utils.js');
 
 // Here goes test for tests...
 should(`Test generator`, () => {
@@ -19,6 +20,36 @@ should(`Test generator`, () => {
       { N: 0, b: 2, c: 5 },
     ]
   );
+});
+
+// Byte swapping
+const BYTESWAP_TEST_CASES = [
+  { in: 0x11223344 | 0, out: 0x44332211 | 0 },
+  { in: 0xffeeddcc | 0, out: 0xccddeeff | 0 },
+  { in: 0xccddeeff | 0, out: 0xffeeddcc | 0 },
+];
+
+should('byteSwap', () => {
+  BYTESWAP_TEST_CASES.forEach(test => {
+    assert.deepStrictEqual(test.out, byteSwap(test.in));
+  });
+});
+
+should('byteSwapIfBE', () => {
+  BYTESWAP_TEST_CASES.forEach(test => {
+    if (isLE) {
+      assert.deepStrictEqual(test.in, byteSwapIfBE(test.in));
+    } else {
+      assert.deepStrictEqual(test.out, byteSwapIfBE(test.in));
+    }
+  });
+});
+
+should('byteSwap32', () => {
+  const input = Uint32Array.of([0x11223344, 0xffeeddcc, 0xccddeeff]);
+  const expected = Uint32Array.of([0x44332211, 0xccddeeff, 0xffeeddcc]);
+  byteSwap32(input);
+  assert.deepStrictEqual(expected, input);
 });
 
 if (require.main === module) should.run();

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -30,13 +30,13 @@ const BYTESWAP_TEST_CASES = [
 ];
 
 should('byteSwap', () => {
-  BYTESWAP_TEST_CASES.forEach(test => {
+  BYTESWAP_TEST_CASES.forEach((test) => {
     assert.deepStrictEqual(test.out, byteSwap(test.in));
   });
 });
 
 should('byteSwapIfBE', () => {
-  BYTESWAP_TEST_CASES.forEach(test => {
+  BYTESWAP_TEST_CASES.forEach((test) => {
     if (isLE) {
       assert.deepStrictEqual(test.in, byteSwapIfBE(test.in));
     } else {


### PR DESCRIPTION
This PR adds support for big endian platforms. It adds byte swapping where needed so that all hash functions can run correctly on both big and little endian platforms. It tries to avoid any significant performance degradation on little endian platforms.

The hash families that are affected by this PR are:

 * SHA3
 * Blake
 * Scrypt

All of the other hash families already worked correctly on big endian platforms.

I have included all of the changes in this PR to hopefully make it easy to give feedback on the approach. I'm happy to split it into smaller PRs if preferred.

Most of the byte swapping is done in-place on `Uint32Array`s which gives the best performance of the things I tried. 

In the blake base class (_blake.ts) `update()` function, there is one spot where the byte swapping is done on the `data32` `Uint32Array` which is backed by the input message. The byte swapping is reversed before the `update()` function returns but while the `update()` function is running the users input message will have been mutated if they passed it in as a `Uint32Array`. I'm not sure if its ok for the input to be temporarily mutated but, if not, I have a different fix that avoids mutation but has a bit worse performance.

Except for that spot, all other byte swapping should be done only on internal or output buffers.

Thanks in advance for looking at this. I'm happy to make any changes necessary.