### PR TITLE
Use XOF constructor wrapper for cShake

### DIFF
--- a/src/sha3-addons.ts
+++ b/src/sha3-addons.ts
@@ -54,7 +54,7 @@ function cshakePers(hash: Keccak, opts: cShakeOpts = {}): Keccak {
 }
 
 const gencShake = (suffix: number, blockLen: number, outputLen: number) =>
-  wrapConstructorWithOpts<Keccak, cShakeOpts>((opts: cShakeOpts = {}) =>
+  wrapXOFConstructorWithOpts<Keccak, cShakeOpts>((opts: cShakeOpts = {}) =>
     cshakePers(new Keccak(blockLen, suffix, chooseLen(opts, outputLen), true), opts)
   );
 


### PR DESCRIPTION
Switch to the XOF constructor wrapper to make the xof and xofInto methods available for cShake.