### PR TITLE
legacy nodejs compatibility: getRandomBytes

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         node:
+          - 14
           - 16
           - 18
           - 20

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         node:
+          - 16
           - 18
           - 20
           - 22

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -252,5 +252,9 @@ export function randomBytes(bytesLength = 32): Uint8Array {
   if (crypto && typeof crypto.getRandomValues === 'function') {
     return crypto.getRandomValues(new Uint8Array(bytesLength));
   }
+  // Legacy Node.js compatibility
+  if (crypto && typeof crypto.randomBytes === 'function') {
+    return crypto.randomBytes(bytesLength);
+  }
   throw new Error('crypto.getRandomValues must be defined');
 }


### PR DESCRIPTION
- fix: support `randomBytes` for older Node.js versions
  - [`crypto.getRandomValues`](https://nodejs.org/docs/latest-v18.x/api/crypto.html#cryptogetrandomvaluestypedarray) is only available on Node.js versions v17+.
  - [`crypto.randomBytes`](https://nodejs.org/docs/latest-v16.x/api/crypto.html#crypto_crypto_randombytes_size_callback) provides the same API as `randomBytes`, with the same randomness guarantees as `crypto.getRandomValues`.
  - This makes the implementation runtime compatible with Node.js v12 and v14.
- github ci: add supported nodejs v16 to test matrix
  - Adds coverage for already supported version 
- github ci: add legacy nodejs v14 to test matrix
  - _Figuring that even if it's not officially supported, it could be relevant to monitor compatibility in CI?_
  - v12 is not compatible with the used version of typescript so can not build.

---

### Related
- https://github.com/paulmillr/noble-curves/pull/152