### PR TITLE
add support for nodejs ^14.21.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "typescript": "5.5.2"
       },
       "engines": {
-        "node": ">= 16"
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "typescript": "5.5.2"
   },
   "engines": {
-    "node": ">= 16"
+    "node": "^14.21.3 || >=16"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
`@noble/hashes` is runtime-compatible with Node.js v14 since #94 . This indicates support for last `^14.21.3` (2023-02-16).

Does not add support for non-LTS v15.