### PR TITLE
Release 1.5.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@noble/hashes",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@noble/hashes",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "devDependencies": {
         "@paulmillr/jsbt": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noble/hashes",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Audited & minimal 0-dependency JS implementation of SHA, RIPEMD, BLAKE, HMAC, HKDF, PBKDF & Scrypt",
   "files": [
     "/*.js",


### PR DESCRIPTION
User-facing changes since `1.4.0`:

- Scrypt: relax params check to allow `r: 1, p: 8`
- Export more typescript types: ae060daa6252f3ff2aa2f84e887de0aab491281d
- #95 (#94, #98)
- Single-file exports: #89 & ab27461daf2fde9fb2d43a1fe73eebcecb19f0ca