### PR TITLE
cryptoNode: fall back to Node.js crypto when webcrypto not available

### DIFF
--- a/src/cryptoNode.ts
+++ b/src/cryptoNode.ts
@@ -1,7 +1,11 @@
-// We use WebCrypto aka globalThis.crypto, which exists in browsers and node.js 16+.
+// We prefer WebCrypto aka globalThis.crypto, which exists in node.js 16+.
+// Falls back to Node.js built-in crypto for Node.js <=v14
 // See utils.ts for details.
-// The file will throw on node.js 14 and earlier.
 // @ts-ignore
 import * as nc from 'node:crypto';
 export const crypto =
-  nc && typeof nc === 'object' && 'webcrypto' in nc ? (nc.webcrypto as any) : undefined;
+  nc && typeof nc === 'object' && 'webcrypto' in nc
+    ? (nc.webcrypto as any)
+    : nc && typeof nc === 'object' && 'randomBytes' in nc
+      ? nc
+      : undefined;


### PR DESCRIPTION
While Node.js v14 does have a built-in `node:crypto` with the required `randomBytes`, it is not exported under `crypto.webcrypto`. This adds a fallback to use the built-in `crypto` when `webcrypto` is not available.