### PR TITLE
benchmark webcrypto

### DIFF
--- a/benchmark/hashes.js
+++ b/benchmark/hashes.js
@@ -39,12 +39,14 @@ const HASHES = {
     stablelib: (buf) => stable256.hash(buf),
     'fast-sha256': (buf) => fastsha256.hash(buf),
     noble: (buf) => sha256(buf),
+    webcrypto: (buf) => globalThis.crypto.subtle.digest('SHA-256', buf),
   },
   SHA384: {
     node: (buf) => crypto_createHash('sha384').update(buf).digest(),
     'crypto-browserify': (buf) => createHash('sha384').update(buf).digest(),
     stablelib: (buf) => stable2_384.hash(buf),
     noble: (buf) => sha384(buf),
+    webcrypto: (buf) => globalThis.crypto.subtle.digest('SHA-384', buf),
   },
   SHA512: {
     node: (buf) => crypto_createHash('sha512').update(buf).digest(),
@@ -52,6 +54,7 @@ const HASHES = {
     'crypto-browserify': (buf) => createHash('sha512').update(buf).digest(),
     stablelib: (buf) => stable2_512.hash(buf),
     noble: (buf) => sha512(buf),
+    webcrypto: (buf) => globalThis.crypto.subtle.digest('SHA-512', buf),
   },
   'SHA3-256, keccak256, shake256': {
     node: (buf) => crypto_createHash('sha3-256').update(buf).digest(),
@@ -90,6 +93,10 @@ const HASHES = {
     'crypto-browserify': (buf) => createHmac('sha256', buf).update(buf).digest(),
     stablelib: (buf) => new stableHmac.HMAC(stable256.SHA256, buf).update(buf).digest(),
     noble: (buf) => hmac(sha256, buf, buf),
+    webcrypto: async (buf) => {
+      const key = await globalThis.crypto.subtle.importKey('raw', buf, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+      return await globalThis.crypto.subtle.sign('HMAC', key, buf);
+    },
   },
 };
 

--- a/benchmark/kdf.js
+++ b/benchmark/kdf.js
@@ -55,6 +55,10 @@ const KDF = {
     stablelib: (iters) => stablePBKDF2(stable256.SHA256, password, salt, iters, 32),
     noble: (iters) => pbkdf2(sha256, password, salt, { c: iters, dkLen: 32 }),
     'noble (async)': (iters) => pbkdf2Async(sha256, password, salt, { c: iters, dkLen: 32 }),
+    webcrypto: async (iters) => {
+      const key = await globalThis.crypto.subtle.importKey('raw', password, 'PBKDF2', false, ['deriveBits']);
+      return await globalThis.crypto.subtle.deriveBits({ name: 'PBKDF2', hash: 'SHA-256', salt: salt, iterations: iters }, key, 32 * 8);
+    },
   },
   'PBKDF2-HMAC-SHA512': {
     node: (iters) => crypto.pbkdf2Sync(password, salt, iters, 64, 'sha512'),
@@ -70,6 +74,10 @@ const KDF = {
     stablelib: (iters) => stablePBKDF2(stable512.SHA512, password, salt, iters, 64),
     noble: (iters) => pbkdf2(sha512, password, salt, { c: iters, dkLen: 64 }),
     'noble (async)': (iters) => pbkdf2Async(sha512, password, salt, { c: iters, dkLen: 64 }),
+    webcrypto: async (iters) => {
+      const key = await globalThis.crypto.subtle.importKey('raw', password, 'PBKDF2', false, ['deriveBits']);
+      return await globalThis.crypto.subtle.deriveBits({ name: 'PBKDF2', hash: 'SHA-512', salt: salt, iterations: iters }, key, 64 * 8);
+    },
   },
   'Scrypt r: 8, p: 1, n:': {
     node: (iters) =>


### PR DESCRIPTION
I was interested in getting benchmarks with native WebCrypto as well.

The results are interesting:
* `SHA*` hashes are 10 times slower then native NodeJS `crypto`
* But `PBKDF2-HMAC-SHA*` are comparable in performance with NodeJS `crypto`