### PR TITLE
test: fix slow-* tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "test:bun": "bun test/index.ts",
     "test:deno": "deno --allow-env --allow-read test/index.ts",
     "test:node20": "cd test; npx tsc; node compiled/test/index.js",
-    "test:dos": "node test/slow-dos.test.ts",
-    "test:big": "node test/slow-big.test.ts",
-    "test:kdf": "node test/slow-kdf.test.ts"
+    "test:dos": "node --experimental-strip-types test/slow-dos.test.ts",
+    "test:big": "node --experimental-strip-types test/slow-big.test.ts",
+    "test:kdf": "node --experimental-strip-types test/slow-kdf.test.ts"
   },
   "author": "Paul Miller (https://paulmillr.com)",
   "homepage": "https://paulmillr.com/noble/",

--- a/test/slow-big.test.ts
+++ b/test/slow-big.test.ts
@@ -9,7 +9,7 @@ import { sha256, sha512 } from '../src/sha2.ts';
 import { cshake128 } from '../src/sha3-addons.ts';
 import { bytesToHex, hexToBytes } from '../src/utils.ts';
 import { RANDOM, executeKDFTests } from './generator.ts';
-import { HASHES } from './hashes.test.js';
+import { HASHES } from './hashes.test.ts';
 
 const KB = 1024;
 const MB = 1024 * KB;

--- a/test/slow-dos.test.ts
+++ b/test/slow-dos.test.ts
@@ -7,7 +7,7 @@ import { scrypt, scryptAsync } from '../src/scrypt.ts';
 import { sha256 } from '../src/sha2.ts';
 import { createView } from '../src/utils.ts';
 import { RANDOM } from './generator.ts';
-import { HASHES } from './hashes.test.js';
+import { HASHES } from './hashes.test.ts';
 import { stats } from './utils.ts';
 
 const getTime = () => Number(process.hrtime.bigint());

--- a/test/slow-kdf.test.ts
+++ b/test/slow-kdf.test.ts
@@ -29,7 +29,7 @@ const SCRYPT_CASES = gen({
   N: integer(1, 10),
   r: integer(1, 1024),
   p: integer(1, 1024),
-  dkLen: integer(0, 1024),
+  dkLen: integer(1, 1024),
   pwd: bytes(0, 1024),
   salt: bytes(0, 1024),
 });


### PR DESCRIPTION
1. `--experimental-strip-types` was missing
2. `.ts` extension should be used for imports in strip-types
3. Minumum allowed `dkLen` value is 1 `scrypt`, not 0. Since 1712cc920bd113ea97397916260428c91d796d62