### PR TITLE
fix: adjust scrypt error message for N range

### DIFF
--- a/src/scrypt.ts
+++ b/src/scrypt.ts
@@ -122,7 +122,7 @@ function scryptInit(password: KDFInput, salt: KDFInput, _opts?: ScryptOpts) {
   // https://www.rfc-editor.org/errata_search.php?rfc=7914
   const pow32 = Math.pow(2, 32);
   if (N <= 1 || (N & (N - 1)) !== 0 || N > pow32) {
-    throw new Error('"N" must be a power of 2, and 1 <= N < 2^32');
+    throw new Error('"N" must be a power of 2, and 2^1 <= N <= 2^32');
   }
   if (p < 1 || p > ((pow32 - 1) * 32) / blockSize) {
     throw new Error('"p" must be positive integer <= ((2^32 - 1) * 32) / (128 * r)');


### PR DESCRIPTION
This now matches the actual check

Partially regressed in 1712cc920bd113ea97397916260428c91d796d62 (for lower bound)

For upper bound 2**32 is allowed by the check