### PR TITLE
perf: tiny improvement in scrypt

### DIFF
--- a/src/scrypt.ts
+++ b/src/scrypt.ts
@@ -198,7 +198,7 @@ export function scrypt(password: KDFInput, salt: KDFInput, opts: ScryptOpts): Ui
     blockMixCb();
     for (let i = 0; i < N; i++) {
       // First u32 of the last 64-byte block (u32 is LE)
-      // & (N - 1) is % N as N is a power of 2; >>> 0 for unsigned, input fits in u32
+      // & (N - 1) is % N as N is a power of 2, N & (N - 1) = 0 is checked above; >>> 0 for unsigned, input fits in u32
       const j = (B32[Pi + blockSize32 - 16] & (N - 1)) >>> 0; // j = Integrify(X) % iterations
       for (let k = 0; k < blockSize32; k++) tmp[k] = B32[Pi + k] ^ V[j * blockSize32 + k]; // tmp = B ^ V[j]
       BlockMix(tmp, 0, B32, Pi, r); // B = BlockMix(B ^ V[j])
@@ -237,7 +237,7 @@ export async function scryptAsync(
     blockMixCb();
     await asyncLoop(N, asyncTick, () => {
       // First u32 of the last 64-byte block (u32 is LE)
-      // & (N - 1) is % N as N is a power of 2; >>> 0 for unsigned, input fits in u32
+      // & (N - 1) is % N as N is a power of 2, N & (N - 1) = 0 is checked above; >>> 0 for unsigned, input fits in u32
       const j = (B32[Pi + blockSize32 - 16] & (N - 1)) >>> 0; // j = Integrify(X) % iterations
       for (let k = 0; k < blockSize32; k++) tmp[k] = B32[Pi + k] ^ V[j * blockSize32 + k]; // tmp = B ^ V[j]
       BlockMix(tmp, 0, B32, Pi, r); // B = BlockMix(B ^ V[j])


### PR DESCRIPTION
I see an ~4% improvement from not using `% N` inside loop over N (and casting to int32)

N is always a power of two, as checked above