### PR TITLE
Add canXOF property in HMAC _cloneInto

### DIFF
--- a/src/hmac.ts
+++ b/src/hmac.ts
@@ -76,12 +76,13 @@ export class _HMAC<T extends Hash<T>> implements Hash<_HMAC<T>> {
     // Create new instance without calling constructor since the key
     // is already in state and we don't know it.
     to ||= Object.create(Object.getPrototypeOf(this), {});
-    const { oHash, iHash, finished, destroyed, blockLen, outputLen } = this;
+    const { oHash, iHash, finished, destroyed, blockLen, outputLen, canXOF } = this;
     to = to as this;
     to.finished = finished;
     to.destroyed = destroyed;
     to.blockLen = blockLen;
     to.outputLen = outputLen;
+    to.canXOF = canXOF;
     to.oHash = oHash._cloneInto(to.oHash);
     to.iHash = iHash._cloneInto(to.iHash);
     return to;


### PR DESCRIPTION
It wasn't copied or initialized with the prototype as constructor was never called
Should be no real effect as it was false and undefined is falsy