### PR TITLE
Export _blake.js and _u64.js internal helper modules

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -3,7 +3,9 @@
   "version": "2.3.0",
   "exports": {
     ".": "./src/index.ts",
+    "./_blake.js": "./src/_blake.ts",
     "./_md.js": "./src/_md.ts",
+    "./_u64.js": "./src/_u64.ts",
     "./argon2.js": "./src/argon2.ts",
     "./blake1.js": "./src/blake1.ts",
     "./blake2.js": "./src/blake2.ts",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
   },
   "exports": {
     ".": "./index.js",
+    "./_blake.js": "./_blake.js",
     "./_md.js": "./_md.js",
+    "./_u64.js": "./_u64.js",
     "./argon2.js": "./argon2.js",
     "./blake1.js": "./blake1.js",
     "./blake2.js": "./blake2.js",

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -1,0 +1,26 @@
+import { describe, it } from '@paulmillr/jsbt/test.js';
+import { ok } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+// Subpaths exposed on both npm (package.json) and JSR (jsr.json) exports maps.
+// _md.js is already exported; _blake.js / _u64.js are the same class of internal
+// helper module and are imported directly by downstream packages building BLAKE
+// variants on top of noble primitives (see issue #136).
+const INTERNALS = ['./_blake.js', './_u64.js'];
+
+const pkgExports = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8')).exports;
+const jsrExports = JSON.parse(readFileSync(join(ROOT, 'jsr.json'), 'utf8')).exports;
+
+describe('exports', () => {
+  it('package.json exposes _blake and _u64 internals', () => {
+    for (const sub of INTERNALS) ok(sub in pkgExports, `package.json exports map is missing ${sub}`);
+  });
+  it('jsr.json exposes _blake and _u64 internals', () => {
+    for (const sub of INTERNALS) ok(sub in jsrExports, `jsr.json exports map is missing ${sub}`);
+  });
+});
+
+it.runWhen(import.meta.url);

--- a/test/index.ts
+++ b/test/index.ts
@@ -30,6 +30,7 @@ async function run() {
     import('./noble-hashes-only.test.ts'),
     import('./u64.test.ts'),
     import('./utils.test.ts'),
+    import('./exports.test.ts'),
   ]);
   init(variant, platform);
   avcpTests(false, variant, platform);


### PR DESCRIPTION
## Context

Closes #136. `@noble/hashes` ships two internal helper modules — `src/_blake.ts` and `src/_u64.ts` (compiled to `_blake.js` / `_u64.js` plus `.d.ts`) — which are imported internally by `blake1`, `blake2`, `blake3`, `sha2`, `sha3`, `argon2` and `_md`. The built artifacts are already included in the published tarball (`files: ["*.js", "*.d.ts", "src"]`).

However, unlike `./_md.js` — the same class of internal helper module — `./_blake.js` and `./_u64.js` are missing from the `exports` map in both `package.json` and `jsr.json`. Because Node enforces `exports`, downstream packages that import these subpaths directly (e.g. wrappers re-exporting noble's symbols, or packages building BLAKE variants on noble's primitives) fail with `ERR_PACKAGE_PATH_NOT_EXPORTED` on 2.2.0+.

## Fix

Add the two missing entries to both export maps, mirroring the existing `_md.js` entry:
- `package.json`: `"./_blake.js": "./_blake.js"`, `"./_u64.js": "./_u64.js"`
- `jsr.json`: `"./_blake.js": "./src/_blake.ts"`, `"./_u64.js": "./src/_u64.ts"`

No source changes needed — the modules already build and ship.

## Test plan

- New `test/exports.test.ts` asserts both subpaths are present in both export maps (fails on current `main`, passes after the fix).
- Wired into `test/index.ts` so it runs under `npm test`.
- `node test/exports.test.ts` → RED on `main` ("missing ./_blake.js"), GREEN after.
- Verified `npm run build` emits `_u64.js`/`_u64.d.ts`/`_blake.js`/`_blake.d.ts`, and `import('@noble/hashes/_u64.js')` / `import('@noble/hashes/_blake.js')` resolve and export the expected symbols (`rotr32H`, `toBig`, `BSIGMA`, `G1s`, `G2s`, …).

Happy to adjust if you'd prefer to keep the `exports` map strictly minimal.