### PR TITLE
utils: reject non-well-formed strings in utf8ToBytes

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -612,6 +612,7 @@ declare const TextEncoder: any;
  * @param str - string to encode
  * @returns UTF-8 encoded bytes.
  * @throws On wrong argument types. {@link TypeError}
+ * @throws On non-well-formed strings. {@link SyntaxError}
  * @example
  * Encode a string as UTF-8 bytes.
  * ```ts
@@ -620,6 +621,24 @@ declare const TextEncoder: any;
  */
 export function utf8ToBytes(str: string): TRet<Uint8Array> {
   if (typeof str !== 'string') throw new TypeError('string expected');
+  // TextEncoder converts every unpaired UTF-16 surrogate to U+FFFD, so distinct
+  // inputs like '\ud800' and '\udfff' collapse to the same bytes and would hash
+  // identically (https://github.com/paulmillr/noble-hashes/issues/133). Reject
+  // non-well-formed strings to keep hashes collision-free. On engines without
+  // String.prototype.isWellFormed, encodeURI throws a URIError for unpaired
+  // surrogates, providing an equivalent check without a polyfill.
+  let wellFormed = false;
+  if (typeof (str as any).isWellFormed === 'function')
+    wellFormed = (str as any).isWellFormed();
+  else {
+    try {
+      encodeURI(str);
+      wellFormed = true;
+    } catch {
+      wellFormed = false;
+    }
+  }
+  if (!wellFormed) throw new SyntaxError('Input is not a well-formed string');
   return new Uint8Array(new TextEncoder().encode(str)); // https://bugzil.la/1681809
 }
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -88,6 +88,26 @@ describe('utils', () => {
     throws(() => u.copyBytes(new Uint16Array([0x0102, 0x0304]) as any), TypeError);
     throws(() => u.copyBytes(new DataView(new ArrayBuffer(4)) as any), TypeError);
   });
+  it('utf8ToBytes rejects non-well-formed strings (noble-hashes#133)', () => {
+    // TextEncoder replaces every unpaired UTF-16 surrogate with U+FFFD, so
+    // distinct inputs like '\ud800' and '\udfff' previously produced identical
+    // bytes and collided in hashes/signatures. They must be rejected instead.
+    throws(() => u.utf8ToBytes('\ud800'), SyntaxError);
+    throws(() => u.utf8ToBytes('\udfff'), SyntaxError);
+    throws(() => u.utf8ToBytes('\udc00'), SyntaxError);
+    throws(() => u.utf8ToBytes('\udc00\ud800'), SyntaxError);
+    throws(() => u.utf8ToBytes('abc \ud800 def'), SyntaxError);
+  });
+  it('utf8ToBytes encodes well-formed strings', () => {
+    eql(u.utf8ToBytes('abc'), Uint8Array.from([97, 98, 99]));
+    // A valid surrogate pair (U+1F600) is well-formed and must be accepted.
+    eql(
+      u.utf8ToBytes('see 😀 <-'),
+      Uint8Array.from([0x73, 0x65, 0x65, 0x20, 0xf0, 0x9f, 0x98, 0x80, 0x20, 0x3c, 0x2d])
+    );
+    // A literal U+FFFD is well-formed and must be accepted.
+    eql(u.utf8ToBytes('�'), Uint8Array.from([0xef, 0xbf, 0xbd]));
+  });
 });
 
 describe('utils etc', () => {


### PR DESCRIPTION
## Problem

`utf8ToBytes` delegates encoding to `TextEncoder`, which silently converts every unpaired UTF-16 surrogate to U+FFFD. Distinct input strings such as `'\ud800'` and `'\udfff'` therefore collapse to the *same* bytes and produce identical hashes/signatures, while still being distinct strings that survive `JSON.stringify`/`JSON.parse` and transport. Reproduced in #133:

```js
sha256(utf8ToBytes('\ud800')).toHex() === sha256(utf8ToBytes('\udfff')).toHex()
// both: '83d544ccc223c057d2bf80d3f2a32982c32c3c0db8e2674820da5064783fb097'
```

This also breaks chunked hashing: encoding each chunk of a stream independently destroys valid surrogate pairs split across chunk boundaries, so different well-formed messages hash identically.

## Root cause

`TextEncoder.encode(str)` performs the destructive DOMString → USVString conversion (unpaired surrogates → U+FFFD) with no well-formedness check, so the byte representation no longer uniquely identifies the input string.

## Fix

Reject non-well-formed strings before encoding. Use `String.prototype.isWellFormed` where the runtime provides it (Node ≥ 20, modern browsers), and fall back to `encodeURI` — which throws `URIError` on unpaired surrogates — on engines without it (e.g. Hermes). Two short code paths, no polyfill, no dependencies.

Non-well-formed input now throws `SyntaxError` instead of silently producing colliding bytes. Valid input (ASCII, valid surrogate pairs such as emoji, and a literal U+FFFD) is unaffected.

## Test

Added tests in `test/utils.test.ts`:
- `utf8ToBytes` rejects lone/reversed surrogate inputs with `SyntaxError`.
- `utf8ToBytes` still encodes well-formed strings (incl. a valid surrogate pair and a literal U+FFFD) correctly.

Run: `JSBT_FILTER=utf8ToBytes JSBT_FAST=0 node test/utils.test.ts`

Fixes #133