### PR TITLE
utils: let asyncLoop/nextTick yield to the event loop (use scheduler.yield when available)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -556,16 +556,21 @@ export function hexToBytes(hex: string): TRet<Uint8Array> {
 }
 
 /**
- * There is no setImmediate in browser and setTimeout is slow.
- * This yields to the Promise/microtask scheduler queue, not to timers or the
- * full macrotask event loop.
+ * Yields control back to the event loop.
+ *
+ * Prefers the Cooperative Scheduling API (`scheduler.yield()`, Chrome 129+,
+ * Safari 18.4+, Firefox 138+), which actually lets the browser render frames,
+ * handle input events and run timers. Without it, falls back to an immediately
+ * resolved promise (microtask) — the previous fast path.
  * @example
  * Yield to the next scheduler tick.
  * ```ts
  * await nextTick();
  * ```
  */
-export const nextTick = async (): Promise<void> => {};
+export const nextTick = async (): Promise<void> => {
+  if (globalThis.scheduler?.yield) await globalThis.scheduler.yield();
+};
 
 /**
  * Returns control to the Promise/microtask scheduler every `tick`

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -256,6 +256,45 @@ describe('assert', () => {
     await rejects(() => u.asyncLoop(1, Number.NaN, () => {}));
     await rejects(() => u.asyncLoop(1, 0, 0 as never));
   });
+  it('asyncLoop yields to the event loop (timers fire mid-loop)', async () => {
+    // Regression test for https://github.com/paulmillr/noble-hashes/issues/113
+    // asyncLoop used to only await an immediately-resolved promise (a microtask),
+    // which never releases the macrotask/event loop: the page still hangs while
+    // the loop runs and timers cannot fire until it finishes. Node exposes no
+    // `scheduler` global, so simulate the browser Cooperative Scheduling API to
+    // exercise the code path the fix relies on.
+    const prev = (globalThis as any).scheduler;
+    let fired = false;
+    let firedDuringLoop = false;
+    let loopDone = false;
+    Object.defineProperty(globalThis, 'scheduler', {
+      value: { yield: () => new Promise((resolve) => setTimeout(resolve, 0)) },
+      configurable: true,
+      writable: true,
+    });
+    try {
+      const t = setTimeout(() => {
+        fired = true;
+        firedDuringLoop = !loopDone;
+      }, 5);
+      // ~1-2ms of synchronous work per iteration with tick=1 => yields every iteration.
+      await u.asyncLoop(50, 1, () => {
+        for (let j = 0; j < 2e6; j++);
+      });
+      loopDone = true;
+      clearTimeout(t);
+      eql(fired, true, 'a timer must fire while asyncLoop is running');
+      eql(firedDuringLoop, true, 'the timer must fire BEFORE the loop completes');
+    } finally {
+      if (prev === undefined) delete (globalThis as any).scheduler;
+      else
+        Object.defineProperty(globalThis, 'scheduler', {
+          value: prev,
+          configurable: true,
+          writable: true,
+        });
+    }
+  });
 });
 
 it.runWhen(import.meta.url);


### PR DESCRIPTION
Fixes #113

`nextTick()` (and therefore `asyncLoop()`, used by async `scrypt`/`pbkdf2`/`argon2`) only awaited an immediately-resolved promise. That queues on the Promise/microtask queue only, so control is never returned to the macrotask event loop: a page still freezes for the whole loop, and timers (progress bars, spinners) cannot fire until the loop finishes.

This PR makes `nextTick()` use the Cooperative Scheduling API (`globalThis.scheduler?.yield()`, Chrome 129+ / Safari 18.4+ / Firefox 138+) when available, which yields to the actual event loop so rendering, input events and timers can run. When the API is unavailable, it keeps the previous microtask fast path exactly as before (the trade-off the existing comment already documents).

Verification:
- Added a regression test in `test/utils.test.ts` that simulates the browser scheduler (Node has no `scheduler` global) and asserts a 5ms `setTimeout` fires *before* the loop completes. It fails on the current code (the timer can only fire after the loop) and passes with this change.
- `node test/utils.test.ts` and `npm run build` (strict `tsc`) both pass.

Note: `src/utils.ts` was also touched by a previous, unrelated PR from this author (#140, `utf8ToBytes`), which is now closed — it does not overlap with `asyncLoop`/`nextTick`.