### PR TITLE
docs: fix dead fuzzing link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ The library has been audited:
 
 It is tested against official (ACVP / KAT) vectors, cross-library chained hashing,
 sliding-window length sweeps and property-based tests (fast-check),
-and is being fuzzed in [the separate repo](https://github.com/paulmillr/fuzzing).
+and is being fuzzed in [the separate repo](https://github.com/paulmillr/cryptofuzz).
 
 If you see anything unusual: investigate and report.
 


### PR DESCRIPTION
closes #119

## the bug

The README's testing section links "the separate repo" for fuzzing to `https://github.com/paulmillr/fuzzing`, which **404s** (no such repo).

## the fix

The repo that actually fuzzes noble-hashes is [`paulmillr/cryptofuzz`](https://github.com/paulmillr/cryptofuzz) - it ships a dedicated harness under [`modules/noble-hashes/`](https://github.com/paulmillr/cryptofuzz/tree/master/modules/noble-hashes) (`harness.js`, `module.cpp`, `module.h`). Repointed the link there.

One-line doc change, no code touched.
